### PR TITLE
fix: use router-link

### DIFF
--- a/Angular InstantSearch/routing-angular-router/src/app/index/index.component.html
+++ b/Angular InstantSearch/routing-angular-router/src/app/index/index.component.html
@@ -1,5 +1,5 @@
 <div>
-    <a href="/search">
-        Let's search!
-    </a>
+  <a [routerLink]="['search']">
+    Let's search!
+  </a>
 </div>

--- a/Angular InstantSearch/routing-full-url/src/app/index/index.component.html
+++ b/Angular InstantSearch/routing-full-url/src/app/index/index.component.html
@@ -1,6 +1,6 @@
 <div>
   Go to
-  <a href="/search/q/phone/brands/apple/p/1">
+  <a [routerLink]="['/search/q/phone/brands/apple/p/1']">
     /search/q/phone/brands/apple/p/1
   </a>
 </div>

--- a/Angular InstantSearch/routing-state-mapping/src/app/index/index.component.html
+++ b/Angular InstantSearch/routing-state-mapping/src/app/index/index.component.html
@@ -1,5 +1,5 @@
 <div>
-  <a href="/search">
+  <a [routerLink]="['/search']">
     Let's search!
   </a>
 </div>


### PR DESCRIPTION
This PR uses the `routerLink` directive rather than `href`. 

It prevents the browser to completely refresh the page when we transition from one page to another.