### PR TITLE
chore: update TypeScript to 2.8.4

### DIFF
--- a/Angular InstantSearch/algolia-insights/package.json
+++ b/Angular InstantSearch/algolia-insights/package.json
@@ -46,6 +46,6 @@
     "protractor": "6.0.0",
     "ts-node": "8.1.0",
     "tslint": "5.17.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/algolia-insights/yarn.lock
+++ b/Angular InstantSearch/algolia-insights/yarn.lock
@@ -7548,10 +7548,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/autocomplete-results-page/package.json
+++ b/Angular InstantSearch/autocomplete-results-page/package.json
@@ -49,6 +49,6 @@
     "protractor": "6.0.0",
     "ts-node": "8.1.0",
     "tslint": "5.17.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/autocomplete-results-page/yarn.lock
+++ b/Angular InstantSearch/autocomplete-results-page/yarn.lock
@@ -7094,10 +7094,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/conditional-request/package.json
+++ b/Angular InstantSearch/conditional-request/package.json
@@ -46,6 +46,6 @@
     "prettier": "1.17.1",
     "ts-node": "8.1.0",
     "tslint": "5.17.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/conditional-request/yarn.lock
+++ b/Angular InstantSearch/conditional-request/yarn.lock
@@ -6944,10 +6944,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/debounced-search-box/package.json
+++ b/Angular InstantSearch/debounced-search-box/package.json
@@ -46,6 +46,6 @@
     "protractor": "6.0.0",
     "ts-node": "8.1.0",
     "tslint": "5.17.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/debounced-search-box/yarn.lock
+++ b/Angular InstantSearch/debounced-search-box/yarn.lock
@@ -7548,10 +7548,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/extending-widgets/package.json
+++ b/Angular InstantSearch/extending-widgets/package.json
@@ -46,6 +46,6 @@
     "protractor": "6.0.0",
     "ts-node": "8.1.0",
     "tslint": "5.17.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/extending-widgets/yarn.lock
+++ b/Angular InstantSearch/extending-widgets/yarn.lock
@@ -7538,10 +7538,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/geo-search/package.json
+++ b/Angular InstantSearch/geo-search/package.json
@@ -48,6 +48,6 @@
     "protractor": "6.0.0",
     "ts-node": "8.1.0",
     "tslint": "5.17.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/geo-search/yarn.lock
+++ b/Angular InstantSearch/geo-search/yarn.lock
@@ -7078,10 +7078,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/getting-started/package.json
+++ b/Angular InstantSearch/getting-started/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser-dynamic": "6.1.10",
     "@angular/router": "6.1.10",
     "angular-instantsearch": "3.0.0-beta.2",
-    "instantsearch.js":"3.4.0",
+    "instantsearch.js": "3.4.0",
     "core-js": "2.6.7",
     "rxjs": "6.2.0",
     "zone.js": "0.9.1"
@@ -29,7 +29,6 @@
   "devDependencies": {
     "@angular/compiler-cli": "6.1.10",
     "@angular-devkit/build-angular": "0.13.8",
-    "typescript": "2.7.2",
     "@angular/cli": "7.3.8",
     "@angular/language-service": "6.1.10",
     "@types/jasmine": "3.3.12",
@@ -45,6 +44,7 @@
     "karma-jasmine-html-reporter": "0.2.2",
     "protractor": "6.0.0",
     "ts-node": "8.1.0",
-    "tslint": "5.17.0"
+    "tslint": "5.17.0",
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/getting-started/yarn.lock
+++ b/Angular InstantSearch/getting-started/yarn.lock
@@ -7527,10 +7527,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/infinite-scroll/package.json
+++ b/Angular InstantSearch/infinite-scroll/package.json
@@ -23,7 +23,7 @@
     "@trademe/ng-defer-load": "3.0.1",
     "algoliasearch": "3.33.0",
     "angular-instantsearch": "3.0.0-beta.2",
-    "instantsearch.js":"3.4.0",
+    "instantsearch.js": "3.4.0",
     "core-js": "2.6.7",
     "rxjs": "6.3.3",
     "zone.js": "0.9.1"
@@ -48,6 +48,6 @@
     "protractor": "6.0.0",
     "ts-node": "8.1.0",
     "tslint": "5.17.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/infinite-scroll/yarn.lock
+++ b/Angular InstantSearch/infinite-scroll/yarn.lock
@@ -7078,10 +7078,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/loading-indicator/package.json
+++ b/Angular InstantSearch/loading-indicator/package.json
@@ -46,6 +46,6 @@
     "protractor": "6.0.0",
     "ts-node": "8.1.0",
     "tslint": "5.17.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/loading-indicator/yarn.lock
+++ b/Angular InstantSearch/loading-indicator/yarn.lock
@@ -7548,10 +7548,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/manipulating-lists/filtering/package.json
+++ b/Angular InstantSearch/manipulating-lists/filtering/package.json
@@ -47,6 +47,6 @@
     "protractor": "6.0.0",
     "ts-node": "8.1.0",
     "tslint": "5.17.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/manipulating-lists/filtering/yarn.lock
+++ b/Angular InstantSearch/manipulating-lists/filtering/yarn.lock
@@ -7548,10 +7548,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/manipulating-lists/sorting/package.json
+++ b/Angular InstantSearch/manipulating-lists/sorting/package.json
@@ -47,6 +47,6 @@
     "protractor": "6.0.0",
     "ts-node": "8.1.0",
     "tslint": "5.17.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/manipulating-lists/sorting/yarn.lock
+++ b/Angular InstantSearch/manipulating-lists/sorting/yarn.lock
@@ -7548,10 +7548,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/multi-index-autocomplete/package.json
+++ b/Angular InstantSearch/multi-index-autocomplete/package.json
@@ -24,7 +24,7 @@
     "@angular/router": "6.1.10",
     "algoliasearch": "3.33.0",
     "angular-instantsearch": "3.0.0-beta.2",
-    "instantsearch.js":"3.4.0",
+    "instantsearch.js": "3.4.0",
     "core-js": "2.6.7",
     "hammerjs": "2.0.8",
     "rxjs": "6.3.3",
@@ -49,6 +49,6 @@
     "protractor": "6.0.0",
     "ts-node": "8.1.0",
     "tslint": "5.17.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/multi-index-autocomplete/yarn.lock
+++ b/Angular InstantSearch/multi-index-autocomplete/yarn.lock
@@ -7094,10 +7094,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/multi-index-hits/package.json
+++ b/Angular InstantSearch/multi-index-hits/package.json
@@ -22,7 +22,7 @@
     "@angular/router": "6.1.10",
     "algoliasearch": "3.33.0",
     "angular-instantsearch": "3.0.0-beta.2",
-    "instantsearch.js":"3.4.0",
+    "instantsearch.js": "3.4.0",
     "core-js": "2.6.7",
     "rxjs": "6.3.3",
     "zone.js": "0.9.1"
@@ -47,6 +47,6 @@
     "protractor": "6.0.0",
     "ts-node": "8.1.0",
     "tslint": "5.17.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/multi-index-hits/yarn.lock
+++ b/Angular InstantSearch/multi-index-hits/yarn.lock
@@ -7073,10 +7073,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/places/package.json
+++ b/Angular InstantSearch/places/package.json
@@ -22,7 +22,7 @@
     "@angular/router": "6.1.10",
     "algoliasearch": "3.33.0",
     "angular-instantsearch": "3.0.0-beta.2",
-    "instantsearch.js":"3.4.0",
+    "instantsearch.js": "3.4.0",
     "core-js": "2.6.7",
     "places.js": "1.16.4",
     "rxjs": "6.3.3",
@@ -49,6 +49,6 @@
     "protractor": "6.0.0",
     "ts-node": "8.1.0",
     "tslint": "5.17.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/places/yarn.lock
+++ b/Angular InstantSearch/places/yarn.lock
@@ -7111,10 +7111,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/query-suggestions/package.json
+++ b/Angular InstantSearch/query-suggestions/package.json
@@ -24,7 +24,7 @@
     "@angular/router": "6.1.10",
     "algoliasearch": "3.33.0",
     "angular-instantsearch": "3.0.0-beta.2",
-    "instantsearch.js":"3.4.0",
+    "instantsearch.js": "3.4.0",
     "core-js": "2.6.7",
     "hammerjs": "2.0.8",
     "rxjs": "6.3.3",
@@ -50,6 +50,6 @@
     "protractor": "6.0.0",
     "ts-node": "8.1.0",
     "tslint": "5.17.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/query-suggestions/yarn.lock
+++ b/Angular InstantSearch/query-suggestions/yarn.lock
@@ -7099,10 +7099,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/refresh/package.json
+++ b/Angular InstantSearch/refresh/package.json
@@ -46,6 +46,6 @@
     "protractor": "6.0.0",
     "ts-node": "8.1.0",
     "tslint": "5.17.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/refresh/yarn.lock
+++ b/Angular InstantSearch/refresh/yarn.lock
@@ -7548,10 +7548,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/routing-angular-router/package.json
+++ b/Angular InstantSearch/routing-angular-router/package.json
@@ -46,6 +46,6 @@
     "protractor": "6.0.0",
     "ts-node": "8.1.0",
     "tslint": "5.17.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/routing-angular-router/yarn.lock
+++ b/Angular InstantSearch/routing-angular-router/yarn.lock
@@ -7548,10 +7548,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/routing-basic/package.json
+++ b/Angular InstantSearch/routing-basic/package.json
@@ -46,6 +46,6 @@
     "protractor": "6.0.0",
     "ts-node": "8.1.0",
     "tslint": "5.17.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/routing-basic/yarn.lock
+++ b/Angular InstantSearch/routing-basic/yarn.lock
@@ -7548,10 +7548,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/routing-full-url/package.json
+++ b/Angular InstantSearch/routing-full-url/package.json
@@ -46,6 +46,6 @@
     "protractor": "6.0.0",
     "ts-node": "8.1.0",
     "tslint": "5.17.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/routing-full-url/yarn.lock
+++ b/Angular InstantSearch/routing-full-url/yarn.lock
@@ -7548,10 +7548,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/routing-state-mapping/package.json
+++ b/Angular InstantSearch/routing-state-mapping/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser-dynamic": "6.1.10",
     "@angular/router": "6.1.10",
     "angular-instantsearch": "3.0.0-beta.2",
-    "instantsearch.js":"3.4.0",
+    "instantsearch.js": "3.4.0",
     "core-js": "2.6.7",
     "rxjs": "6.2.0",
     "zone.js": "0.9.1"
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@angular/compiler-cli": "6.1.10",
     "@angular-devkit/build-angular": "0.13.8",
-    "typescript": "2.7.2",
+    "typescript": "2.8.4",
     "@angular/cli": "7.3.8",
     "@angular/language-service": "6.1.10",
     "@types/jasmine": "3.3.12",

--- a/Angular InstantSearch/routing-state-mapping/yarn.lock
+++ b/Angular InstantSearch/routing-state-mapping/yarn.lock
@@ -7527,10 +7527,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"

--- a/Angular InstantSearch/secured-api-keys/package.json
+++ b/Angular InstantSearch/secured-api-keys/package.json
@@ -47,6 +47,6 @@
     "protractor": "6.0.0",
     "ts-node": "8.1.0",
     "tslint": "5.17.0",
-    "typescript": "2.7.2"
+    "typescript": "2.8.4"
   }
 }

--- a/Angular InstantSearch/secured-api-keys/yarn.lock
+++ b/Angular InstantSearch/secured-api-keys/yarn.lock
@@ -7746,10 +7746,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
+typescript@2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
 
 typescript@3.2.4:
   version "3.2.4"


### PR DESCRIPTION
This PR bumps TypeScript to `2.8.4`. It allows us to use the latest `@types/algoliasearch`.