### PR TITLE
feat(autocomplete): update Query Suggestions to Autocomplete v1

### DIFF
--- a/InstantSearch.js/query-suggestions/index.html
+++ b/InstantSearch.js/query-suggestions/index.html
@@ -23,8 +23,17 @@
 
   <body>
     <div class="container">
-      <div id="autocomplete"></div>
-      <div id="hits"></div>
+      <div class="search-panel">
+        <div class="search-panel__filters">
+          <div id="categories"></div>
+        </div>
+
+        <div class="search-panel__results">
+          <div id="autocomplete"></div>
+
+          <div id="hits"></div>
+        </div>
+      </div>
     </div>
 
     <script src="src/app.js"></script>

--- a/InstantSearch.js/query-suggestions/index.html
+++ b/InstantSearch.js/query-suggestions/index.html
@@ -1,34 +1,32 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <meta name="theme-color" content="#000000" />
 
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta name="theme-color" content="#000000">
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <link rel="shortcut icon" href="./favicon.png" />
 
-  <link rel="manifest" href="./manifest.webmanifest">
-  <link rel="shortcut icon" href="./favicon.png">
+    <link rel="stylesheet" href="src/index.css" />
+    <link rel="stylesheet" href="src/app.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/satellite-min.css"
+    />
 
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.1.0/themes/algolia.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/selectize@0.12.6/dist/css/selectize.css">
-  <link rel="stylesheet" href="./src/index.css">
-  <link rel="stylesheet" href="./src/app.css">
+    <title>InstantSearch.js Query Suggestions</title>
+  </head>
 
-  <title>query-suggestions</title>
-</head>
+  <body>
+    <div class="container">
+      <div id="autocomplete"></div>
+      <div id="hits"></div>
+    </div>
 
-<body>
-  <div class="container">
-    <h1>InstantSearch.js - Query suggestions</h1>
-    <div id="autocomplete"></div>
-    <div id="hits"></div>
-  </div>
-
-  <script src="https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/selectize@0.12.6/dist/js/standalone/selectize.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/algoliasearch@4/dist/algoliasearch-lite.umd.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@4"></script>
-  <script src="./src/app.js"></script>
-</body>
-
+    <script src="src/app.js"></script>
+  </body>
 </html>

--- a/InstantSearch.js/query-suggestions/package.json
+++ b/InstantSearch.js/query-suggestions/package.json
@@ -17,5 +17,10 @@
     "eslint-plugin-prettier": "3.1.0",
     "parcel-bundler": "1.12.3",
     "prettier": "1.17.1"
+  },
+  "dependencies": {
+    "@algolia/autocomplete-js": "1.0.0-alpha.34",
+    "algoliasearch": "4.5.1",
+    "instantsearch.js": "4.8.3"
   }
 }

--- a/InstantSearch.js/query-suggestions/src/app.css
+++ b/InstantSearch.js/query-suggestions/src/app.css
@@ -33,13 +33,13 @@
 
 .autocomplete-item-content {
   display: flex;
+  grid-gap: 0.5rem;
   align-items: center;
-  margin-left: 0.5rem;
 }
 
 .item-info {
   font-size: 0.9rem;
-  margin-left: 0.25rem;
+  padding-left: 1.5rem;
   color: #666;
 }
 

--- a/InstantSearch.js/query-suggestions/src/app.css
+++ b/InstantSearch.js/query-suggestions/src/app.css
@@ -5,6 +5,27 @@
   padding: 1rem;
 }
 
+.search-panel {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  grid-gap: 1rem;
+}
+
+.search-panel__filters {
+  min-width: 200px;
+}
+
+.ais-HierarchicalMenu-item--selected.ais-HierarchicalMenu-item--parent
+  > div:first-of-type
+  .ais-HierarchicalMenu-label {
+  font-weight: bold;
+}
+
+.ais-HierarchicalMenu-item--selected:not(.ais-HierarchicalMenu-item--parent)
+  .ais-HierarchicalMenu-label {
+  font-weight: bold;
+}
+
 .autocomplete-item {
   display: flex;
   align-items: center;
@@ -114,7 +135,6 @@
   box-shadow: 0 0 0 1px rgba(35, 38, 59, 0.05),
     0 8px 16px -4px rgba(35, 38, 59, 0.25);
   margin-top: 5px;
-  max-width: 480px;
   position: absolute;
   width: 100%;
 }

--- a/InstantSearch.js/query-suggestions/src/app.css
+++ b/InstantSearch.js/query-suggestions/src/app.css
@@ -1,32 +1,155 @@
-h1 {
+.container {
+  margin: 0 auto;
+  width: 100%;
+  max-width: 860px;
+  padding: 1rem;
+}
+
+.autocomplete-item {
+  display: flex;
+  align-items: center;
+}
+
+.autocomplete-item-content {
+  display: flex;
+  align-items: center;
+  margin-left: 0.5rem;
+}
+
+.item-info {
+  font-size: 0.9rem;
+  margin-left: 0.25rem;
+  color: #666;
+}
+
+.item-category {
+  font-style: italic;
+}
+
+.aa-Form {
+  position: relative;
   margin-bottom: 1rem;
 }
 
-em {
-  background: cyan;
+.aa-Label {
+  align-items: center;
+  color: #777;
+  cursor: initial;
+  display: flex;
+  height: 100%;
+  padding: 0 0.5rem;
+  position: absolute;
+  z-index: 2;
+}
+
+.aa-InputWrapper {
+  background-color: #fff;
+  max-width: 100%;
+  min-height: 2.5rem;
+  position: relative;
+  width: 100%;
+}
+
+.aa-Input {
+  appearance: none;
+  background: none;
+  border: 1px solid #d6d6e7;
+  border-radius: 3px;
+  box-shadow: rgba(119, 122, 175, 0.3) 0 1px 4px 0 inset;
+  caret-color: #5a5e9a;
+  color: #23263b;
+  font: inherit;
+  height: 100%;
+  position: absolute;
+  width: 100%;
+  z-index: 2;
+}
+
+.aa-Input::-webkit-search-decoration,
+.aa-Input::-webkit-search-cancel-button,
+.aa-Input::-webkit-search-results-button,
+.aa-Input::-webkit-search-results-decoration {
+  -webkit-appearance: none;
+}
+
+.aa-Completion {
+  color: #999;
+  left: 1px;
+  position: absolute;
+  transform: translateY(50%);
+  z-index: 1;
+}
+
+.aa-Input,
+.aa-Completion {
+  padding: 0 2.25rem;
+}
+
+.aa-Input::placeholder {
+  color: #5a5e9a;
+}
+
+.aa-Input:focus {
+  border-color: #3c4fe0;
+  box-shadow: rgba(35, 38, 59, 0.05) 0 1px 0 0;
+  outline: currentcolor none medium;
+}
+
+.aa-ResetButton {
+  background: none;
+  border: 0;
+  cursor: pointer;
+  height: 100%;
+  padding: 0 0.5rem;
+  position: absolute;
+  right: 0;
+  z-index: 2;
+}
+
+.aa-Dropdown {
+  z-index: 1;
+  background-color: #fff;
+  border: 1px solid rgba(150, 150, 150, 0.16);
+  border-radius: 3px;
+  box-shadow: 0 0 0 1px rgba(35, 38, 59, 0.05),
+    0 8px 16px -4px rgba(35, 38, 59, 0.25);
+  margin-top: 5px;
+  max-width: 480px;
+  position: absolute;
+  width: 100%;
+}
+
+.aa-Dropdown--stalled {
+  filter: grayscale(1);
+  opacity: 0.5;
+  transition: opacity 200ms ease-in;
+}
+
+.aa-Dropdown a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.aa-Dropdown ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.aa-Item {
+  color: #23263b;
+  cursor: pointer;
+  padding: 0.5rem;
+  display: flex;
+  align-items: center;
+}
+
+.aa-Item mark {
+  background: none;
   font-style: normal;
+  font-weight: bold;
 }
 
-.container {
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 1em;
-}
-
-.ais-hits {
-  margin-top: 1em;
-}
-
-.ais-Hits-item {
-  margin-bottom: 2em;
-}
-
-.hit-name {
-  margin-bottom: 0.5em;
-}
-
-.hit-description {
-  color: #888;
-  font-size: 14px;
-  margin-bottom: 0.5em;
+.aa-Item[aria-selected='true'] {
+  background-color: #f5f5fa;
 }

--- a/InstantSearch.js/query-suggestions/src/app.js
+++ b/InstantSearch.js/query-suggestions/src/app.js
@@ -7,12 +7,7 @@ import {
   connectSearchBox,
   connectRefinementList,
 } from 'instantsearch.js/es/connectors';
-import {
-  configure,
-  index,
-  hits,
-  refinementList,
-} from 'instantsearch.js/es/widgets';
+import { configure, index, hits } from 'instantsearch.js/es/widgets';
 
 const searchClient = algoliasearch(
   'latency',

--- a/InstantSearch.js/query-suggestions/src/app.js
+++ b/InstantSearch.js/query-suggestions/src/app.js
@@ -93,18 +93,20 @@ function createAutocompleteSearchBox() {
                       },
                     ];
 
-                    // We only add the category items to the first suggestion.
+                    // We only add the category item to the first suggestion.
                     if (i === 0) {
                       const categories = current.instant_search.facets.exact_matches.categories.map(
                         x => x.value
                       );
                       const firstLevelCategory = categories[0];
 
-                      items.push({
-                        query: current.query,
-                        category: firstLevelCategory,
-                        ...current,
-                      });
+                      if (firstLevelCategory) {
+                        items.push({
+                          query: current.query,
+                          category: firstLevelCategory,
+                          ...current,
+                        });
+                      }
                     }
 
                     acc.push(...items);

--- a/InstantSearch.js/query-suggestions/src/app.js
+++ b/InstantSearch.js/query-suggestions/src/app.js
@@ -191,8 +191,8 @@ search.addWidgets([
     configure({
       hitsPerPage: 5,
     }),
-    // We need to add a refinement list with the same attribute as the parent index
-    // to reset the filter and to search suggestions in all categories.
+    // We need to add a hierarchical menu with the same attribute as the parent
+    // index to reset the filter and to search suggestions in all categories.
     virtualHierarchicalMenu({
       attributes: [
         'hierarchicalCategories.lvl0',

--- a/InstantSearch.js/query-suggestions/src/app.js
+++ b/InstantSearch.js/query-suggestions/src/app.js
@@ -85,46 +85,43 @@ function createAutocompleteSearchBox() {
                 },
                 getSuggestions() {
                   return currentIndex.hits.reduce((acc, current, i) => {
-                    const itemCategories = current.instant_search.facets.exact_matches.categories.map(
-                      x => x.value
-                    );
-
-                    const categories =
-                      i === 0 && itemCategories.length > 0
-                        ? [itemCategories[0]]
-                        : [];
-
-                    const itemWithoutCategories = {
-                      query: current.query,
-                      categories: [],
-                      ...current,
-                    };
-
-                    const items = categories.map(category => {
-                      return {
+                    const items = [
+                      {
                         query: current.query,
-                        categories: [category],
+                        category: null,
                         ...current,
-                      };
-                    });
+                      },
+                    ];
 
-                    acc.push(itemWithoutCategories, ...items);
+                    // We only add the category items to the first suggestion.
+                    if (i === 0) {
+                      const categories = current.instant_search.facets.exact_matches.categories.map(
+                        x => x.value
+                      );
+                      const firstLevelCategory = categories[0];
+
+                      items.push({
+                        query: current.query,
+                        category: firstLevelCategory,
+                        ...current,
+                      });
+                    }
+
+                    acc.push(...items);
 
                     return acc;
                   }, []);
                 },
                 onSelect({ suggestion }) {
                   setUiState(prevUiState => {
-                    const category = suggestion.categories[0];
-
                     return {
                       ...prevUiState,
                       instant_search: {
                         ...prevUiState.instant_search,
                         query: suggestion.query,
                         hierarchicalMenu: {
-                          'hierarchicalCategories.lvl0': category
-                            ? [category]
+                          'hierarchicalCategories.lvl0': suggestion.category
+                            ? [suggestion.category]
                             : [],
                         },
                       },
@@ -133,14 +130,14 @@ function createAutocompleteSearchBox() {
                 },
                 templates: {
                   item({ item }) {
-                    const category = item.categories[0];
-
-                    if (category) {
+                    if (item.category) {
                       return `
                         <div class="autocomplete-item">
                           <div class="autocomplete-item-content">
                             <div class="item-info">
-                              in <span class="item-category">${category}</span>
+                              in <span class="item-category">${
+                                item.category
+                              }</span>
                             </div>
                           </div>
                         </div>

--- a/InstantSearch.js/query-suggestions/src/index.css
+++ b/InstantSearch.js/query-suggestions/src/index.css
@@ -1,10 +1,11 @@
-body,
-h1 {
-  margin: 0;
-  padding: 0;
+* {
+  box-sizing: border-box;
 }
 
 body {
+  background-color: #fcfcfd;
+  color: #333;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
     Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  margin: 0;
 }

--- a/InstantSearch.js/query-suggestions/yarn.lock
+++ b/InstantSearch.js/query-suggestions/yarn.lock
@@ -2,6 +2,132 @@
 # yarn lockfile v1
 
 
+"@algolia/autocomplete-core@^1.0.0-alpha.34":
+  version "1.0.0-alpha.34"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-core/-/autocomplete-core-1.0.0-alpha.34.tgz#29abd7f23d490eeb47a02961121fb54cceddaa33"
+  integrity sha512-a7+YKEoTfLDgL/eat/EuZoz8aui2K2yYvWzojLKfn1nq58sbuU2snXc+Nc3RmdgOAN2SzUIucmeRtLLmx4sVwQ==
+
+"@algolia/autocomplete-js@1.0.0-alpha.34":
+  version "1.0.0-alpha.34"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-js/-/autocomplete-js-1.0.0-alpha.34.tgz#2a219d320983d468460ea45ecf4d00c16491b303"
+  integrity sha512-+wRkZAkExuynYJSWYkwax6MWLTkzhDbzSpJ5tCn1t0NekI3w7+qJisVyx+2RnhAWF0DsidZR9/iK95PcXV5ujA==
+  dependencies:
+    "@algolia/autocomplete-core" "^1.0.0-alpha.34"
+    "@algolia/autocomplete-preset-algolia" "^1.0.0-alpha.34"
+    "@algolia/client-search" "4.5.1"
+
+"@algolia/autocomplete-preset-algolia@^1.0.0-alpha.34":
+  version "1.0.0-alpha.34"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.0.0-alpha.34.tgz#e7eda5ca37ae92dc928f47b5bfe1a57f2ae6316c"
+  integrity sha512-jcIkcvI7o4HRff+8ht2oN7lDRj3ZYao91XM+S8svfYG0h9ksTt/BTVifqfCwRTJoTq1/0f3hGctQaUAegr4nLw==
+  dependencies:
+    "@algolia/client-search" "4.5.1"
+    algoliasearch "4.5.1"
+
+"@algolia/cache-browser-local-storage@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.5.1.tgz#bdf58c30795683fd48310c552c3a10f10fb26e2b"
+  integrity sha512-TAQHRHaCUAR0bNhUHG0CnO6FTx3EMPwZQrjPuNS6kHvCQ/H8dVD0sLsHyM8C7U4j33xPQCWi9TBnSx8cYXNmNw==
+  dependencies:
+    "@algolia/cache-common" "4.5.1"
+
+"@algolia/cache-common@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-common/-/cache-common-4.5.1.tgz#3aefda3382dc30b67091b01a3d7461d937082821"
+  integrity sha512-Sux+pcedQi9sfScIiQdl6pEaTVl712qM9OblvDhnaeF1v6lf4jyTlRTiBLP7YBLuvO1Yo54W3maf03kmz9PVhA==
+
+"@algolia/cache-in-memory@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-in-memory/-/cache-in-memory-4.5.1.tgz#127cd473474f62300a157f4ee3b3f6836003cf35"
+  integrity sha512-fzwAtBFwveuG+E5T/namChEIvdVl0DoV3djV1C078b/JpO5+DeAwuXIJGYbyl950u170n5NEYuIwYG+R6h4lJQ==
+  dependencies:
+    "@algolia/cache-common" "4.5.1"
+
+"@algolia/client-account@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@algolia/client-account/-/client-account-4.5.1.tgz#7d3ccda09d3c7849b171c915da0833e7649bab33"
+  integrity sha512-2WFEaI7Zf4ljnBsSAS4e+YylZ5glovm78xFg4E1JKA8PE6M+TeIgUY6HO2ouLh2dqQKxc9UfdAT1Loo/dha2iQ==
+  dependencies:
+    "@algolia/client-common" "4.5.1"
+    "@algolia/client-search" "4.5.1"
+    "@algolia/transporter" "4.5.1"
+
+"@algolia/client-analytics@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@algolia/client-analytics/-/client-analytics-4.5.1.tgz#bfc2a7292a9ea789ca3c99f79b1f96c08d378828"
+  integrity sha512-bTmZUU8zhZMWBeGEQ/TVqLoL3OOT0benU0HtS3iOnQURwb+AOCv3RsgZvkj2djp+M24Q6P8/L34uBJMmCurbLg==
+  dependencies:
+    "@algolia/client-common" "4.5.1"
+    "@algolia/client-search" "4.5.1"
+    "@algolia/requester-common" "4.5.1"
+    "@algolia/transporter" "4.5.1"
+
+"@algolia/client-common@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-4.5.1.tgz#91a401eba6eafd7cc74a0aeccb4c6e6cb1e72026"
+  integrity sha512-5CpIf8IK1hke7q+N4e+A4TWdFXVJ5Qwyaa0xS84DrDO8HQ7vfYbDvG1oYa9hVEtGn6c3WVKPAvuWynK+fXQQCA==
+  dependencies:
+    "@algolia/requester-common" "4.5.1"
+    "@algolia/transporter" "4.5.1"
+
+"@algolia/client-recommendation@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@algolia/client-recommendation/-/client-recommendation-4.5.1.tgz#57a1fe30987c90b10d5119b8e7d6cd91c423e54c"
+  integrity sha512-GiFrNSImoEBUQICjFBEoxPGzrjWji8PY9GeMg2CNvOYcRQ0Xt0Y36v9GN53NLjvB7QdQ2FlE1Cuv/PLUfS/aQQ==
+  dependencies:
+    "@algolia/client-common" "4.5.1"
+    "@algolia/requester-common" "4.5.1"
+    "@algolia/transporter" "4.5.1"
+
+"@algolia/client-search@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-4.5.1.tgz#cb798c99d6621e29a36334b92205518a74ecdf3e"
+  integrity sha512-wjuOTte9Auo9Cg4fL0709PjeJ9rXFh4okYUrOt/2SWqQid6DSdZOp+BtyaHKV3E94sj+SlmMxkMUacYluYg5zA==
+  dependencies:
+    "@algolia/client-common" "4.5.1"
+    "@algolia/requester-common" "4.5.1"
+    "@algolia/transporter" "4.5.1"
+
+"@algolia/logger-common@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@algolia/logger-common/-/logger-common-4.5.1.tgz#18d654516369a28e25ad7eee4fc2882fd47ed8ec"
+  integrity sha512-ZoVnGriinlLHlkvn5K7djOUn1/1IeTjU8rDzOJ3t06T+2hQytgJghaX7rSwKIeH4CjWMy61w8jLisuGJRBOEeg==
+
+"@algolia/logger-console@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@algolia/logger-console/-/logger-console-4.5.1.tgz#c9def97c20bea5eecb4b07f8d3f733c0192d1761"
+  integrity sha512-1qa7K18+uAgxyWuguayaDS5ViiZFcOjI3J5ACBb0i/n7RsXUo149lP6mwmx6TIU7s135hT0f0TCqnvfMvN1ilA==
+  dependencies:
+    "@algolia/logger-common" "4.5.1"
+
+"@algolia/requester-browser-xhr@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.5.1.tgz#838b55209d2c83572df261338f7cd75be36de401"
+  integrity sha512-tsQz+9pZw9dwPm/wMvZDpsWFZgmghLjXi4c3O4rfwoP/Ikum5fhle5fiR14yb4Lw4WlOQ1AJIHJvrg1qLIG8hQ==
+  dependencies:
+    "@algolia/requester-common" "4.5.1"
+
+"@algolia/requester-common@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-common/-/requester-common-4.5.1.tgz#a34d02daa6093e112b528d3bcd5a5467c00ba823"
+  integrity sha512-bPCiLvhHKXaka7f5FLtheChToz0yHVhvza64naFJRRh/3kC0nvyrvQ0ogjiydiSrGIfdNDyyTVfKGdk4gS5gyA==
+
+"@algolia/requester-node-http@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-node-http/-/requester-node-http-4.5.1.tgz#29911c104c6714a5cb29d3991f2b50c52301e091"
+  integrity sha512-BfFc2h9eQOKu1gGs3DtQO7GrVZW/rxUgpJVLja4UVQyGplJyTCrFgkTyfl+8rb3MkNgA/S2LNo7cKNSPfpqeAQ==
+  dependencies:
+    "@algolia/requester-common" "4.5.1"
+
+"@algolia/transporter@4.5.1":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@algolia/transporter/-/transporter-4.5.1.tgz#e0a5c64f358b6751f867001f51f384d6fc7ede14"
+  integrity sha512-asPDNToDAPhH0tM6qKGTn1l0wTlNUbekpa1ifZ6v+qhSjo3VdqGyp+2VeciJOBW/wVHXh3HUbAcycvLERRlCLg==
+  dependencies:
+    "@algolia/cache-common" "4.5.1"
+    "@algolia/logger-common" "4.5.1"
+    "@algolia/requester-common" "4.5.1"
+
 "@babel/code-frame@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz#2a02643368de80916162be70865c97774f3adbd9"
@@ -782,6 +908,11 @@
     "@parcel/utils" "^1.11.0"
     physical-cpu-count "^2.0.0"
 
+"@types/googlemaps@^3.39.6":
+  version "3.40.2"
+  resolved "https://registry.yarnpkg.com/@types/googlemaps/-/googlemaps-3.40.2.tgz#282fc5383ffdb035e1698f846c941cad501f02cb"
+  integrity sha512-LYlp497JZ/AjsjmGQMHcKmqO/MkUSLeUtsY++CQwy3VN8rqeotMacxnCF3xoGd8LphNqDdgQX7PL6qG0Pmh0Hw==
+
 "@types/node@^10.11.7":
   version "10.12.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.0.tgz#ea6dcbddbc5b584c83f06c60e82736d8fbb0c235"
@@ -856,6 +987,33 @@ ajv@^6.5.5:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+algoliasearch-helper@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.2.2.tgz#12451c8e368935348453c8879785b20e1788c33c"
+  integrity sha512-/3XvE33R+gQKaiPdy3nmHYqhF8hqIu8xnlOicVxb1fD6uMFmxW8rGLzzrRfsPfxgAfm+c1NslLb3TzQVIB8aVA==
+  dependencies:
+    events "^1.1.1"
+
+algoliasearch@4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-4.5.1.tgz#fd20cd76f6ba3fbecdd4e11bdaefefb44abc0b38"
+  integrity sha512-b6yT1vWMlBdVObQipKxvt0M6SEvGetVj+FFFlo0Fy06gkdj6WCJaS4t10Q/hC3I2VG9QmpCqlK3Esgg1y1E+uw==
+  dependencies:
+    "@algolia/cache-browser-local-storage" "4.5.1"
+    "@algolia/cache-common" "4.5.1"
+    "@algolia/cache-in-memory" "4.5.1"
+    "@algolia/client-account" "4.5.1"
+    "@algolia/client-analytics" "4.5.1"
+    "@algolia/client-common" "4.5.1"
+    "@algolia/client-recommendation" "4.5.1"
+    "@algolia/client-search" "4.5.1"
+    "@algolia/logger-common" "4.5.1"
+    "@algolia/logger-console" "4.5.1"
+    "@algolia/requester-browser-xhr" "4.5.1"
+    "@algolia/requester-common" "4.5.1"
+    "@algolia/requester-node-http" "4.5.1"
+    "@algolia/transporter" "4.5.1"
 
 alphanum-sort@^1.0.0:
   version "1.0.2"
@@ -1436,6 +1594,11 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+classnames@^2.2.5:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
 cli-cursor@^2.1.0:
   version "2.1.0"
@@ -2469,7 +2632,7 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-events@^1.0.0:
+events@^1.0.0, events@^1.1.0, events@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
@@ -2907,6 +3070,14 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
+hogan.js@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/hogan.js/-/hogan.js-3.0.2.tgz#4cd9e1abd4294146e7679e41d7898732b02c7bfd"
+  integrity sha1-TNnhq9QpQUbnZ55B14mHMrAse/0=
+  dependencies:
+    mkdirp "0.3.0"
+    nopt "1.0.10"
+
 hosted-git-info@^2.1.4:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
@@ -3074,6 +3245,20 @@ inquirer@^6.1.0:
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
+
+instantsearch.js@4.8.3:
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.8.3.tgz#f9bff4370c7250ddc674c14fce078a69cda2c841"
+  integrity sha512-qU3ybRfwkTkftuTdPODGev04pa+4sk4Jve2iTQRDHMAMTO02F10/doV8IuxmGymVsk1kb8O/15Xcux69D/m9BQ==
+  dependencies:
+    "@types/googlemaps" "^3.39.6"
+    algoliasearch-helper "^3.2.2"
+    classnames "^2.2.5"
+    events "^1.1.0"
+    hogan.js "^3.0.2"
+    preact "^10.0.0"
+    prop-types "^15.5.10"
+    qs "^6.5.1"
 
 invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.4"
@@ -3581,7 +3766,7 @@ log-symbols@^2.2.0:
   dependencies:
     chalk "^2.0.1"
 
-loose-envify@^1.0.0:
+loose-envify@^1.0.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -3740,6 +3925,11 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
+mkdirp@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
+  integrity sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=
+
 mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -3871,6 +4061,13 @@ node-releases@^1.1.8:
   integrity sha512-oic3GT4OtbWWKfRolz5Syw0Xus0KRFxeorLNj0s93ofX6PWyuzKjsiGxsCtWktBwwmTF6DdRRf2KreGqeOk5KA==
   dependencies:
     semver "^5.3.0"
+
+nopt@1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  integrity sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=
+  dependencies:
+    abbrev "1"
 
 nopt@^4.0.1, nopt@~4.0.1:
   version "4.0.1"
@@ -4873,6 +5070,11 @@ posthtml@^0.11.2, posthtml@^0.11.3:
     posthtml-parser "^0.3.3"
     posthtml-render "^1.1.0"
 
+preact@^10.0.0:
+  version "10.5.5"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.5.tgz#c6c172ca751df27483350b8ab622abc12956e997"
+  integrity sha512-5ONLNH1SXMzzbQoExZX4TELemNt+TEDb622xXFNfZngjjM9qtrzseJt+EfiUu4TZ6EJ95X5sE1ES4yqHFSIdhg==
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -4909,6 +5111,15 @@ progress@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
   integrity sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==
+
+prop-types@^15.5.10:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 proto-list@~1.2.1:
   version "1.2.4"
@@ -4956,6 +5167,11 @@ q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
+
+qs@^6.5.1:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
+  integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
 
 qs@~6.5.2:
   version "6.5.2"
@@ -5010,6 +5226,11 @@ rc@^1.2.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-is@^16.8.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 read-pkg-up@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This updates the [*Query Suggestions* guide](https://www.algolia.com/doc/guides/building-search-ui/resources/ui-and-ux-patterns/in-depth/query-suggestions/js/) to Autocomplete v1.

## Implementation

I use a child index that takes care of the Query Suggestions index. This index is "detached" in the sense that it doesn't refine the main index query on every key stroke, but only on select and on submit via the [`setUiState`](https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/#widget-param-setuistate) API. In addition to refining the search, it applies the categories from the selected item. On submit, we reset all categories.

## Preview

| Before | After |
|---|---|
| [Demo →](https://codesandbox.io/s/github/algolia/doc-code-samples/blob/master/InstantSearch.js/query-suggestions) | [Demo →](https://codesandbox.io/s/github/algolia/doc-code-samples/blob/feat/autocomplete-query-suggestions/InstantSearch.js/query-suggestions) |

## Notes

The Query Suggestions are not reverse-highlighted, but just highlighted with the [`highlight`](https://www.algolia.com/doc/api-reference/widgets/highlight/js/) helper. Instead of implementing this feature on the sandbox itself (and all the other ones), I believe we should support this in InstantSearch.js.