### PR TITLE
fix(vue): update the wrong index name in the example

### DIFF
--- a/Vue InstantSearch/routing-vue-router/src/views/Home.vue
+++ b/Vue InstantSearch/routing-vue-router/src/views/Home.vue
@@ -87,17 +87,17 @@ export default {
         stateMapping: {
           stateToRoute(uiState) {
             return {
-              query: uiState.instant_search.query,
+              query: uiState.demo_ecommerce.query,
               brands:
-                uiState.instant_search.refinementList &&
-                uiState.instant_search.refinementList.brand &&
-                uiState.instant_search.refinementList.brand.join('~'),
-              page: uiState.instant_search.page,
+                uiState.demo_ecommerce.refinementList &&
+                uiState.demo_ecommerce.refinementList.brand &&
+                uiState.demo_ecommerce.refinementList.brand.join('~'),
+              page: uiState.demo_ecommerce.page,
             };
           },
           routeToState(routeState) {
             return {
-              instant_search: {
+              demo_ecommerce: {
                 query: routeState.query,
                 refinementList: {
                   brand: routeState.brands && routeState.brands.split('~'),

--- a/Vue InstantSearch/routing-vue-router/src/views/Home.vue
+++ b/Vue InstantSearch/routing-vue-router/src/views/Home.vue
@@ -13,7 +13,7 @@
     <div class="container">
       <ais-instant-search
         :search-client="searchClient"
-        index-name="demo_ecommerce"
+        index-name="instant_search"
         :routing="routing"
       >
         <div class="search-panel">
@@ -47,8 +47,8 @@ export default {
     const vueRouter = this.$router;
     return {
       searchClient: algoliasearch(
-        'B1G2GM9NG0',
-        'aadef574be1f9252bb48d4ea09b5cfe5'
+        'latency',
+        '6be0576ff61c053d5f9a3225e2a90f76'
       ),
       routing: {
         router: {
@@ -87,17 +87,17 @@ export default {
         stateMapping: {
           stateToRoute(uiState) {
             return {
-              query: uiState.demo_ecommerce.query,
+              query: uiState.instant_search.query,
               brands:
-                uiState.demo_ecommerce.refinementList &&
-                uiState.demo_ecommerce.refinementList.brand &&
-                uiState.demo_ecommerce.refinementList.brand.join('~'),
-              page: uiState.demo_ecommerce.page,
+                uiState.instant_search.refinementList &&
+                uiState.instant_search.refinementList.brand &&
+                uiState.instant_search.refinementList.brand.join('~'),
+              page: uiState.instant_search.page,
             };
           },
           routeToState(routeState) {
             return {
-              demo_ecommerce: {
+              instant_search: {
                 query: routeState.query,
                 refinementList: {
                   brand: routeState.brands && routeState.brands.split('~'),


### PR DESCRIPTION
# Summary

This PR updates the wrong index name (`demo_ecommerce` -> `instant_search`).
The vue-router example was broken.

* before: https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/Vue%20InstantSearch/routing-vue-router
* after: https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix/vue-router/Vue%20InstantSearch/routing-vue-router?file=/src/main.js