### PR TITLE
fix(conditional-request): spread algoliaClient

### DIFF
--- a/Angular InstantSearch/conditional-request/src/app/app.component.ts
+++ b/Angular InstantSearch/conditional-request/src/app/app.component.ts
@@ -7,6 +7,7 @@ const algoliaClient = algoliasearch(
 );
 
 const searchClient = {
+  ...algoliaClient,
   search(requests) {
     if (requests.every(({ params }) => !params.query)) {
       return Promise.resolve({

--- a/InstantSearch.js/conditional-request/src/app.js
+++ b/InstantSearch.js/conditional-request/src/app.js
@@ -6,6 +6,7 @@ const algoliaClient = algoliasearch(
 );
 
 const searchClient = {
+  ...algoliaClient,
   search(requests) {
     if (requests.every(({ params }) => !params.query)) {
       return Promise.resolve({

--- a/React InstantSearch/conditional-request/src/App.js
+++ b/React InstantSearch/conditional-request/src/App.js
@@ -16,6 +16,7 @@ const algoliaClient = algoliasearch(
 );
 
 const searchClient = {
+  ...algoliaClient,
   search(requests) {
     if (requests.every(({ params }) => !params.query)) {
       return Promise.resolve({

--- a/Vue InstantSearch/conditional-request/src/App.vue
+++ b/Vue InstantSearch/conditional-request/src/App.vue
@@ -55,6 +55,7 @@ const algoliaClient = algoliasearch(
 );
 
 const searchClient = {
+  ...algoliaClient,
   search(requests) {
     if (requests.every(({ params }) => !params.query)) {
       return Promise.resolve({


### PR DESCRIPTION
## Summary

This PR spreads `algoliaClient` in `searchClient` in conditional requests examples.

We're mocking `searchClient` but only expose `search` function, so it can lead to unexpected error due to lack of other properties or methods.

In the recent support ticket, insights middleware failed to get appId and apiKey from the searchClient. So we'd better spread the algoliaClient to the searchClient.

rel: https://github.com/algolia/doc/pull/5697