### PR TITLE
chore(node14): update node version for angular projects

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ executors:
   node9:
     docker:
       - image: circleci/node:9
+  node14:
+    docker:
+      - image: cimg/node:14.17.0
 
 commands:
   build_project:
@@ -21,7 +24,7 @@ commands:
             yarn build
 jobs:
   build_angular_projects:
-    executor: node9
+    executor: node14
     steps:
       - checkout
       - build_project:


### PR DESCRIPTION
To upgrade the code samples to their Angular 12 version, we need to use node > 12.
Added node 14 for building angular projects.
I'm not sure yet all examples can build on node 14 before they migrated, let's see if it does :)