### PR TITLE
fix(angular-instantsearch): fix ES module interoperability

### DIFF
--- a/Angular InstantSearch/getting-started/tsconfig.json
+++ b/Angular InstantSearch/getting-started/tsconfig.json
@@ -20,7 +20,8 @@
       "es2018",
       "dom"
     ],
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
The current sandbow is broken because it can't find the default import for `algoliasearch/lite`.

![Capture d’écran 2021-10-01 à 18 50 48](https://user-images.githubusercontent.com/5370675/135658193-e8f9eda8-d447-4ee1-b629-01f73b549936.png)

This fixes it by setting `esModuleInterop` to `true`.

Note that this shouldn't be needed as per [this fix](https://github.com/algolia/algoliasearch-client-javascript/issues/1000). The sandbox uses [recent versions of the client and of TypeScript](https://github.com/algolia/doc-code-samples/blob/master/Angular%20InstantSearch/getting-started/package.json#L21-L40), so there might be something to investigate.