### PR TITLE
fix(Angular InstantSearch): use <link> for satellite styles

### DIFF
--- a/Angular InstantSearch/algolia-insights/src/index.html
+++ b/Angular InstantSearch/algolia-insights/src/index.html
@@ -6,6 +6,7 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link href="https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/satellite.css" rel="stylesheet" />
     <script>
       var ALGOLIA_INSIGHTS_SRC =
         'https://cdn.jsdelivr.net/npm/search-insights@1.2.0';

--- a/Angular InstantSearch/algolia-insights/src/styles.css
+++ b/Angular InstantSearch/algolia-insights/src/styles.css
@@ -1,3 +1,1 @@
 /* You can add global styles to this file, and also import other style files */
-@import 'instantsearch.css/themes/reset.css';
-@import 'instantsearch.css/themes/satellite.css';

--- a/Angular InstantSearch/algolia-insights/tsconfig.json
+++ b/Angular InstantSearch/algolia-insights/tsconfig.json
@@ -13,6 +13,7 @@
     "downlevelIteration": true,
     "experimentalDecorators": true,
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "importHelpers": true,
     "target": "es2017",
     "module": "es2020",

--- a/Angular InstantSearch/autocomplete-results-page/src/index.html
+++ b/Angular InstantSearch/autocomplete-results-page/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link href="https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/satellite.css" rel="stylesheet" />
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/Angular InstantSearch/autocomplete-results-page/src/styles.css
+++ b/Angular InstantSearch/autocomplete-results-page/src/styles.css
@@ -1,6 +1,4 @@
 /* You can add global styles to this file, and also import other style files */
-@import "instantsearch.css/themes/reset.css";
-@import "instantsearch.css/themes/satellite.css";
 
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }

--- a/Angular InstantSearch/autocomplete-results-page/tsconfig.json
+++ b/Angular InstantSearch/autocomplete-results-page/tsconfig.json
@@ -14,6 +14,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
+    "esModuleInterop": true,
     "target": "es2017",
     "module": "es2020",
     "lib": [

--- a/Angular InstantSearch/getting-started/src/index.html
+++ b/Angular InstantSearch/getting-started/src/index.html
@@ -8,6 +8,7 @@
 
   <link rel="manifest" href="manifest.json">
   <link rel="shortcut icon" href="favicon.png">
+  <link href="https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/satellite.css" rel="stylesheet" />
 
   <title>ais-ecommerce-demo-app</title>
 </head>

--- a/Angular InstantSearch/getting-started/src/styles.css
+++ b/Angular InstantSearch/getting-started/src/styles.css
@@ -1,7 +1,4 @@
 /* You can add global styles to this file, and also import other style files */
-@import "instantsearch.css/themes/reset.css";
-@import "instantsearch.css/themes/satellite.css";
-
 body { font-family: sans-serif }
 .ais-SearchBox { margin-bottom: 1em }
 .ais-Pagination { margin-top: 1em }

--- a/Angular InstantSearch/infinite-scroll/src/index.html
+++ b/Angular InstantSearch/infinite-scroll/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link href="https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/satellite.css" rel="stylesheet" />
 </head>
 <body>
   <app-root></app-root>

--- a/Angular InstantSearch/infinite-scroll/src/styles.css
+++ b/Angular InstantSearch/infinite-scroll/src/styles.css
@@ -1,3 +1,1 @@
 /* You can add global styles to this file, and also import other style files */
-@import "instantsearch.css/themes/reset.css";
-@import "instantsearch.css/themes/satellite.css";

--- a/Angular InstantSearch/infinite-scroll/tsconfig.json
+++ b/Angular InstantSearch/infinite-scroll/tsconfig.json
@@ -16,6 +16,7 @@
     "importHelpers": true,
     "target": "es2017",
     "module": "es2020",
+    "esModuleInterop": true,
     "lib": [
       "es2018",
       "dom"

--- a/Angular InstantSearch/multi-index-autocomplete/src/index.html
+++ b/Angular InstantSearch/multi-index-autocomplete/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link href="https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/satellite.css" rel="stylesheet" />
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/Angular InstantSearch/multi-index-autocomplete/src/styles.css
+++ b/Angular InstantSearch/multi-index-autocomplete/src/styles.css
@@ -1,6 +1,4 @@
 /* You can add global styles to this file, and also import other style files */
-@import "instantsearch.css/themes/reset.css";
-@import "instantsearch.css/themes/satellite.css";
 
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }

--- a/Angular InstantSearch/multi-index-autocomplete/tsconfig.json
+++ b/Angular InstantSearch/multi-index-autocomplete/tsconfig.json
@@ -14,6 +14,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
+    "esModuleInterop": true,
     "target": "es2017",
     "module": "es2020",
     "lib": [

--- a/Angular InstantSearch/multi-index-hits/src/index.html
+++ b/Angular InstantSearch/multi-index-hits/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link href="https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/satellite.css" rel="stylesheet" />
 </head>
 <body>
   <app-root></app-root>

--- a/Angular InstantSearch/multi-index-hits/src/styles.css
+++ b/Angular InstantSearch/multi-index-hits/src/styles.css
@@ -1,3 +1,1 @@
 /* You can add global styles to this file, and also import other style files */
-@import "instantsearch.css/themes/reset.css";
-@import "instantsearch.css/themes/satellite.css";

--- a/Angular InstantSearch/multi-index-hits/tsconfig.json
+++ b/Angular InstantSearch/multi-index-hits/tsconfig.json
@@ -16,6 +16,7 @@
     "importHelpers": true,
     "target": "es2017",
     "module": "es2020",
+    "esModuleInterop": true,
     "lib": [
       "es2018",
       "dom"

--- a/Angular InstantSearch/query-suggestions/src/index.html
+++ b/Angular InstantSearch/query-suggestions/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link href="https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/satellite.css" rel="stylesheet" />
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/Angular InstantSearch/refresh/src/index.html
+++ b/Angular InstantSearch/refresh/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link href="https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/satellite.css" rel="stylesheet" />
 </head>
 <body>
   <app-root></app-root>

--- a/Angular InstantSearch/refresh/src/styles.css
+++ b/Angular InstantSearch/refresh/src/styles.css
@@ -1,3 +1,1 @@
 /* You can add global styles to this file, and also import other style files */
-@import "instantsearch.css/themes/reset.css";
-@import "instantsearch.css/themes/satellite.css";

--- a/Angular InstantSearch/refresh/tsconfig.json
+++ b/Angular InstantSearch/refresh/tsconfig.json
@@ -16,6 +16,7 @@
     "importHelpers": true,
     "target": "es2017",
     "module": "es2020",
+    "esModuleInterop": true,
     "lib": [
       "es2018",
       "dom"

--- a/Angular InstantSearch/routing-basic/src/index.html
+++ b/Angular InstantSearch/routing-basic/src/index.html
@@ -6,6 +6,7 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link href="https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/satellite.css" rel="stylesheet" />
   </head>
   <body>
     <app-root></app-root>

--- a/Angular InstantSearch/routing-basic/src/styles.css
+++ b/Angular InstantSearch/routing-basic/src/styles.css
@@ -1,3 +1,1 @@
 /* You can add global styles to this file, and also import other style files */
-@import 'instantsearch.css/themes/reset.css';
-@import 'instantsearch.css/themes/satellite.css';

--- a/Angular InstantSearch/routing-basic/tsconfig.json
+++ b/Angular InstantSearch/routing-basic/tsconfig.json
@@ -16,6 +16,7 @@
     "importHelpers": true,
     "target": "es2017",
     "module": "es2020",
+    "esModuleInterop": true,
     "lib": [
       "es2018",
       "dom"

--- a/Angular InstantSearch/routing-seo-friendly/src/index.html
+++ b/Angular InstantSearch/routing-seo-friendly/src/index.html
@@ -6,6 +6,7 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link href="https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/satellite.css" rel="stylesheet" />
   </head>
   <body>
     <app-root></app-root>

--- a/Angular InstantSearch/routing-seo-friendly/src/styles.css
+++ b/Angular InstantSearch/routing-seo-friendly/src/styles.css
@@ -1,3 +1,1 @@
 /* You can add global styles to this file, and also import other style files */
-@import 'instantsearch.css/themes/reset.css';
-@import 'instantsearch.css/themes/satellite.css';

--- a/Angular InstantSearch/routing-seo-friendly/tsconfig.json
+++ b/Angular InstantSearch/routing-seo-friendly/tsconfig.json
@@ -16,6 +16,7 @@
     "importHelpers": true,
     "target": "es2017",
     "module": "es2020",
+    "esModuleInterop": true,
     "lib": [
       "es2018",
       "dom"

--- a/Angular InstantSearch/routing-state-mapping/src/index.html
+++ b/Angular InstantSearch/routing-state-mapping/src/index.html
@@ -6,6 +6,7 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link href="https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/satellite.css" rel="stylesheet" />
   </head>
   <body>
     <app-root></app-root>

--- a/Angular InstantSearch/routing-state-mapping/src/styles.css
+++ b/Angular InstantSearch/routing-state-mapping/src/styles.css
@@ -1,3 +1,1 @@
 /* You can add global styles to this file, and also import other style files */
-@import 'instantsearch.css/themes/reset.css';
-@import 'instantsearch.css/themes/satellite.css';

--- a/Angular InstantSearch/routing-state-mapping/tsconfig.json
+++ b/Angular InstantSearch/routing-state-mapping/tsconfig.json
@@ -16,6 +16,7 @@
     "importHelpers": true,
     "target": "es2017",
     "module": "es2020",
+    "esModuleInterop": true,
     "lib": [
       "es2018",
       "dom"

--- a/Angular InstantSearch/secured-api-keys/src/index.html
+++ b/Angular InstantSearch/secured-api-keys/src/index.html
@@ -6,6 +6,7 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link href="https://cdn.jsdelivr.net/npm/instantsearch.css@7/themes/satellite.css" rel="stylesheet" />
     <script>
       window.SERVER_DATA = __SERVER_DATA__;
     </script>

--- a/Angular InstantSearch/secured-api-keys/src/styles.css
+++ b/Angular InstantSearch/secured-api-keys/src/styles.css
@@ -1,3 +1,1 @@
 /* You can add global styles to this file, and also import other style files */
-@import 'instantsearch.css/themes/reset.css';
-@import 'instantsearch.css/themes/satellite.css';

--- a/Angular InstantSearch/secured-api-keys/tsconfig.json
+++ b/Angular InstantSearch/secured-api-keys/tsconfig.json
@@ -16,6 +16,7 @@
     "importHelpers": true,
     "target": "es2017",
     "module": "es2020",
+    "esModuleInterop": true,
     "lib": [
       "es2018",
       "dom"


### PR DESCRIPTION
This fixes the compatibility issue with CodeSandbox, of examples running Angular 12.
Examples running Angular 6 still work, and [most have a PR open to update them to 12](https://github.com/algolia/doc-code-samples/issues/255).
I'll be updating other currently open PRs separately: https://github.com/algolia/doc-code-samples/pull/261 and https://github.com/algolia/doc-code-samples/pull/254.

Examples updated in this PR:

[Angular InstantSearch/algolia-insights in codesandbox](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular+InstantSearch/algolia-insights)
[Angular InstantSearch/algolia-insights in stackblitz](https://stackblitz.com/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular%20InstantSearch/algolia-insights)

[Angular InstantSearch/autocomplete-results-page in codesandbox](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular+InstantSearch/autocomplete-results-page)
[Angular InstantSearch/autocomplete-results-page in stackbliz](https://stackbliz.com/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular%20InstantSearch/autocomplete-results-page)

[Angular InstantSearch/getting-started in codesandbox](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular+InstantSearch/getting-started)
[Angular InstantSearch/getting-started in stackblitz](https://stackblitz.com/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular%20InstantSearch/getting-started)

[Angular InstantSearch/infinite-scroll in codesandbox](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular%20InstantSearch/infinite-scroll)  ❌ (this one doesn't work, it's a codesandbox typescript issue https://github.com/codesandbox/codesandbox-client/issues/2634)
[Angular InstantSearch/infinite-scroll in stackblitz](https://stackblitz.com/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular%20InstantSearch/infinite-scroll)

[Angular InstantSearch/multi-index-autocomplete in codesandbox](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular+InstantSearch/multi-index-autocomplete)
[Angular InstantSearch/multi-index-autocomplete in stackblitz](https://stackblitz.com/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular%20InstantSearch/multi-index-autocomplete)

[Angular InstantSearch/multi-index-hits in codesandbox](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular+InstantSearch/multi-index-hits)
[Angular InstantSearch/multi-index-hits in stackblitz](https://stackblitz.com/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular%20InstantSearch/multi-index-hits)

[Angular InstantSearch/refresh in codesandbox](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular+InstantSearch/refresh)
[Angular InstantSearch/refresh in stackblitz](https://stackblitz.com/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular%20InstantSearch/refresh)

[Angular InstantSearch/routing-basic in codesandbox](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular+InstantSearch/routing-basic)
[Angular InstantSearch/routing-basic in stackblitz](https://stackblitz.com/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular%20InstantSearch/routing-basic)

[Angular InstantSearch/routing-seo-friendly in codesandbox](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular+InstantSearch/routing-seo-friendly)
[Angular InstantSearch/routing-seo-friendly in stackblitz](https://stackblitz.com/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular%20InstantSearch/routing-seo-friendly)  ❌ (this one doesn't work, it's a codesandbox typescript issue https://github.com/codesandbox/codesandbox-client/issues/2634)

[Angular InstantSearch/routing-state-mapping in codesandbox](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular+InstantSearch/routing-state-mapping)
[Angular InstantSearch/routing-state-mapping in stackblitz](https://stackblitz.com/github/algolia/doc-code-samples/tree/codesandbox-compat/Angular%20InstantSearch/routing-state-mapping) 


NB: some of the examples still don't work due to a codesandbox issue. We should just use stackblitz for all Angular examples. 


