### PR TITLE
fix(Angular IS): avoid default browser styling

### DIFF
--- a/Angular InstantSearch/algolia-insights/src/styles.css
+++ b/Angular InstantSearch/algolia-insights/src/styles.css
@@ -1,1 +1,11 @@
 /* You can add global styles to this file, and also import other style files */
+body,
+h1 {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
+    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+}

--- a/Angular InstantSearch/autocomplete-results-page/src/styles.css
+++ b/Angular InstantSearch/autocomplete-results-page/src/styles.css
@@ -1,4 +1,11 @@
 /* You can add global styles to this file, and also import other style files */
+body,
+h1 {
+  margin: 0;
+  padding: 0;
+}
 
-html, body { height: 100%; }
-body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
+    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+}

--- a/Angular InstantSearch/infinite-scroll/src/styles.css
+++ b/Angular InstantSearch/infinite-scroll/src/styles.css
@@ -1,1 +1,11 @@
 /* You can add global styles to this file, and also import other style files */
+body,
+h1 {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
+    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+}

--- a/Angular InstantSearch/multi-index-autocomplete/src/styles.css
+++ b/Angular InstantSearch/multi-index-autocomplete/src/styles.css
@@ -1,4 +1,11 @@
 /* You can add global styles to this file, and also import other style files */
+body,
+h1 {
+  margin: 0;
+  padding: 0;
+}
 
-html, body { height: 100%; }
-body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
+    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+}

--- a/Angular InstantSearch/multi-index-hits/src/styles.css
+++ b/Angular InstantSearch/multi-index-hits/src/styles.css
@@ -1,1 +1,11 @@
 /* You can add global styles to this file, and also import other style files */
+body,
+h1 {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
+    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+}

--- a/Angular InstantSearch/query-suggestions/angular.json
+++ b/Angular InstantSearch/query-suggestions/angular.json
@@ -28,7 +28,6 @@
             ],
             "styles": [
               "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
-              "node_modules/instantsearch.css/themes/satellite.css",
               "src/styles.css"
             ],
             "scripts": []
@@ -97,7 +96,6 @@
             ],
             "styles": [
               "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
-              "node_modules/instantsearch.css/themes/satellite.css",
               "src/styles.css"
             ],
             "scripts": []

--- a/Angular InstantSearch/query-suggestions/src/styles.css
+++ b/Angular InstantSearch/query-suggestions/src/styles.css
@@ -9,6 +9,3 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
     Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 }
-
-html, body { height: 100%; }
-body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }

--- a/Angular InstantSearch/refresh/src/styles.css
+++ b/Angular InstantSearch/refresh/src/styles.css
@@ -1,1 +1,11 @@
 /* You can add global styles to this file, and also import other style files */
+body,
+h1 {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
+    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+}

--- a/Angular InstantSearch/routing-basic/src/styles.css
+++ b/Angular InstantSearch/routing-basic/src/styles.css
@@ -1,1 +1,11 @@
 /* You can add global styles to this file, and also import other style files */
+body,
+h1 {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
+    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+}

--- a/Angular InstantSearch/routing-seo-friendly/src/styles.css
+++ b/Angular InstantSearch/routing-seo-friendly/src/styles.css
@@ -1,1 +1,11 @@
 /* You can add global styles to this file, and also import other style files */
+body,
+h1 {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
+    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+}

--- a/Angular InstantSearch/routing-state-mapping/src/styles.css
+++ b/Angular InstantSearch/routing-state-mapping/src/styles.css
@@ -1,1 +1,11 @@
 /* You can add global styles to this file, and also import other style files */
+body,
+h1 {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
+    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+}

--- a/Angular InstantSearch/secured-api-keys/src/styles.css
+++ b/Angular InstantSearch/secured-api-keys/src/styles.css
@@ -1,1 +1,11 @@
 /* You can add global styles to this file, and also import other style files */
+body,
+h1 {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
+    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+}


### PR DESCRIPTION
This PR addresses [this comment](https://github.com/algolia/doc-code-samples/pull/318#pullrequestreview-800364340), adding basic styles for Angular IS examples that display browser default styles.