### PR TITLE
fix(React IS): fix back button behaviour with basic and seo friendly routing

### DIFF
--- a/React InstantSearch/routing-basic/src/App.js
+++ b/React InstantSearch/routing-basic/src/App.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   InstantSearch,
   Hits,
@@ -38,6 +38,10 @@ export function App({ location, history }) {
 
     setSearchState(updatedSearchState);
   }
+
+  useEffect(() => {
+    setSearchState(urlToSearchState(location));
+  }, [location]);
 
   return (
     <div className="container">

--- a/React InstantSearch/routing-seo-friendly/src/App.js
+++ b/React InstantSearch/routing-seo-friendly/src/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   InstantSearch,
   Hits,
@@ -133,17 +133,14 @@ Hit.propTypes = {
   hit: PropTypes.object.isRequired,
 };
 
-let timeout;
-
 const App = ({ location, history }) => {
   const [searchState, setSearchState] = useState(urlToSearchState(location));
+  const debouncedSetStateRef = useRef(null);
 
   const onSearchStateChange = updatedSearchState => {
-    if (timeout) {
-      clearTimeout(timeout);
-    }
+    clearTimeout(debouncedSetStateRef.current);
 
-    timeout = setTimeout(() => {
+    debouncedSetStateRef.current = setTimeout(() => {
       history.push(searchStateToUrl(updatedSearchState), updatedSearchState);
     }, DEBOUNCE_TIME);
 

--- a/React InstantSearch/routing-seo-friendly/src/App.js
+++ b/React InstantSearch/routing-seo-friendly/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   InstantSearch,
   Hits,
@@ -133,21 +133,26 @@ Hit.propTypes = {
   hit: PropTypes.object.isRequired,
 };
 
+let timeout;
+
 const App = ({ location, history }) => {
   const [searchState, setSearchState] = useState(urlToSearchState(location));
-  const [debouncedSetState, setDebouncedSetState] = useState(null);
 
   const onSearchStateChange = updatedSearchState => {
-    clearTimeout(debouncedSetState);
+    if (timeout) {
+      clearTimeout(timeout);
+    }
 
-    setDebouncedSetState(
-      setTimeout(() => {
-        history.push(searchStateToUrl(updatedSearchState), updatedSearchState);
-      }, DEBOUNCE_TIME)
-    );
+    timeout = setTimeout(() => {
+      history.push(searchStateToUrl(updatedSearchState), updatedSearchState);
+    }, DEBOUNCE_TIME);
 
     setSearchState(updatedSearchState);
   };
+
+  useEffect(() => {
+    setSearchState(urlToSearchState(location));
+  }, [location]);
 
   return (
     <div className="container">


### PR DESCRIPTION
This change fixes the behaviour of the back button in basic and SEO friendly routing example
Prior to this change, the examples were missing the bit that updates the externally managed `searchState` when `location` changes:

```jsx
  const [searchState, setSearchState] = useState(urlToSearchState(location));

  useEffect(() => {
    setSearchState(urlToSearchState(location));
  }, [location]);
```

fixes [FX-246](https://algolia.atlassian.net/browse/FX-246)
Related doc PR: https://github.com/algolia/doc/pull/6465