### PR TITLE
feat(React InstantSearch): add Recommend implementation in injected content sample

### DIFF
--- a/React InstantSearch/injected-content/package.json
+++ b/React InstantSearch/injected-content/package.json
@@ -9,6 +9,8 @@
     "lint:fix": "npm run lint -- --fix"
   },
   "dependencies": {
+    "@algolia/recommend": "4.12.0",
+    "@algolia/recommend-react": "1.1.0",
     "algoliasearch": "4.12.0",
     "react": "16.12.0",
     "react-dom": "16.12.0",

--- a/React InstantSearch/injected-content/src/App.css
+++ b/React InstantSearch/injected-content/src/App.css
@@ -132,26 +132,33 @@ em {
   display: block;
 }
 
-.ais-Hits-injected .Recommend {
+.Recommend .ais-Hits-item:first-of-type {
+  color: #00aeff;
+  border-color: currentColor;
+}
+
+.Recommend .ais-Hits-injected .FrequentlyBoughtTogether {
   color: #00aeff;
   background-color: #e5f1f7;
   border-color: currentColor;
   box-shadow: none;
 }
 
-.ais-Hits-injected .Recommend h2 {
+.Recommend .ais-Hits-injected .FrequentlyBoughtTogether h2 {
   margin-top: 0;
 }
 
-.ais-Hits-injected .Recommend ul {
+.Recommend .ais-Hits-injected .FrequentlyBoughtTogether ul {
   margin: 0;
   padding: 0;
   list-style: none;
-  display: flex;
+  flex-grow: 1;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: 1rem;
 }
 
-.ais-Hits-injected .Recommend article {
+.Recommend .ais-Hits-injected .FrequentlyBoughtTogether article {
   margin: 0;
   background-color: #fff;
 }
@@ -177,6 +184,18 @@ em {
   }
 }
 
+@media (min-width: 768px) {
+  .Recommend .ais-Hits-item:first-of-type {
+    border-right: 0;
+  }
+
+  .Recommend .ais-Hits-injected .FrequentlyBoughtTogether {
+    margin-left: 0;
+    width: calc(100% / 4 * 3);
+    border-left: 0;
+  }
+}
+
 @media (max-width: 767px) {
   .ais-Hits-item {
     width: calc(50% - 1rem);
@@ -186,6 +205,19 @@ em {
   .ais-Hits-injected article {
     min-height: 250px;
     height: 100%;
+  }
+
+  .Recommend .ais-Hits-item:first-of-type {
+    border-bottom: 0;
+  }
+
+  .Recommend .ais-Hits-item:first-of-type div {
+    height: 200px;
+  }
+
+  .Recommend .ais-Hits-injected .FrequentlyBoughtTogether {
+    margin-top: 0;
+    border-top: 0;
   }
 
   .sm\:Block-full {

--- a/React InstantSearch/injected-content/src/App.css
+++ b/React InstantSearch/injected-content/src/App.css
@@ -132,6 +132,30 @@ em {
   display: block;
 }
 
+.ais-Hits-injected .Recommend {
+  color: #00aeff;
+  background-color: #e5f1f7;
+  border-color: currentColor;
+  box-shadow: none;
+}
+
+.ais-Hits-injected .Recommend h2 {
+  margin-top: 0;
+}
+
+.ais-Hits-injected .Recommend ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+}
+
+.ais-Hits-injected .Recommend article {
+  margin: 0;
+  background-color: #fff;
+}
+
 .ais-Hits-loadMore {
   width: 100%;
   margin-top: 1rem;

--- a/React InstantSearch/injected-content/src/App.css
+++ b/React InstantSearch/injected-content/src/App.css
@@ -132,7 +132,7 @@ em {
   display: block;
 }
 
-.Recommend .ais-Hits-item:first-of-type {
+.Recommend .ais-Hits-item:nth-of-type(5) {
   color: #00aeff;
   border-color: currentColor;
 }
@@ -186,7 +186,7 @@ em {
 }
 
 @media (min-width: 768px) {
-  .Recommend .ais-Hits-item:first-of-type {
+  .Recommend .ais-Hits-item:nth-of-type(5) {
     border-right: 0;
   }
 
@@ -208,7 +208,7 @@ em {
     height: 100%;
   }
 
-  .Recommend .ais-Hits-item:first-of-type {
+  .Recommend .ais-Hits-item:nth-of-type(5) {
     border-bottom: 0;
   }
 

--- a/React InstantSearch/injected-content/src/App.css
+++ b/React InstantSearch/injected-content/src/App.css
@@ -153,9 +153,6 @@ em {
   margin: 0;
   padding: 0;
   list-style: none;
-  display: grid;
-  grid-auto-columns: minmax(0, 1fr);
-  gap: 1rem;
 }
 
 .Recommend .ais-Hits-injected .FrequentlyBoughtTogether article {
@@ -196,6 +193,9 @@ em {
   }
 
   .Recommend .ais-Hits-injected .FrequentlyBoughtTogether ul {
+    display: grid;
+    grid-auto-columns: minmax(0, 1fr);
+    gap: 1rem;
     grid-auto-flow: column;
   }
 }
@@ -218,6 +218,10 @@ em {
   .Recommend .ais-Hits-injected .FrequentlyBoughtTogether {
     margin-top: 0;
     border-top: 0;
+  }
+
+  .Recommend .ais-Hits-injected .FrequentlyBoughtTogether ul li + li {
+    margin-top: 1rem;
   }
 
   .sm\:Block-full {

--- a/React InstantSearch/injected-content/src/App.css
+++ b/React InstantSearch/injected-content/src/App.css
@@ -141,6 +141,7 @@ em {
   color: #00aeff;
   background-color: #e5f1f7;
   border-color: currentColor;
+  width: 100%;
   box-shadow: none;
 }
 
@@ -154,7 +155,7 @@ em {
   list-style: none;
   flex-grow: 1;
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-auto-flow: column;
   gap: 1rem;
 }
 
@@ -209,10 +210,6 @@ em {
 
   .Recommend .ais-Hits-item:first-of-type {
     border-bottom: 0;
-  }
-
-  .Recommend .ais-Hits-item:first-of-type div {
-    height: 200px;
   }
 
   .Recommend .ais-Hits-injected .FrequentlyBoughtTogether {

--- a/React InstantSearch/injected-content/src/App.css
+++ b/React InstantSearch/injected-content/src/App.css
@@ -153,9 +153,8 @@ em {
   margin: 0;
   padding: 0;
   list-style: none;
-  flex-grow: 1;
   display: grid;
-  grid-auto-flow: column;
+  grid-auto-columns: minmax(0, 1fr);
   gap: 1rem;
 }
 
@@ -194,6 +193,10 @@ em {
     margin-left: 0;
     width: calc(100% / 4 * 3);
     border-left: 0;
+  }
+
+  .Recommend .ais-Hits-injected .FrequentlyBoughtTogether ul {
+    grid-auto-flow: column;
   }
 }
 

--- a/React InstantSearch/injected-content/src/pages/Recommend.js
+++ b/React InstantSearch/injected-content/src/pages/Recommend.js
@@ -1,0 +1,103 @@
+import React from 'react';
+
+import algoliasearch from 'algoliasearch';
+import {
+  Configure,
+  Highlight,
+  InstantSearch,
+  SearchBox,
+} from 'react-instantsearch-dom';
+
+import recommend from '@algolia/recommend';
+import { useFrequentlyBoughtTogether } from '@algolia/recommend-react';
+
+import { InjectedInfiniteHits } from '../InjectedInfiniteHits';
+
+const searchClient = algoliasearch(
+  'XX85YRZZMV',
+  'd17ff64e913b3293cfba3d3665480217'
+);
+
+const recommendClient = recommend(
+  'XX85YRZZMV',
+  'd17ff64e913b3293cfba3d3665480217'
+);
+
+export function Recommend() {
+  return (
+    <InstantSearch
+      searchClient={searchClient}
+      indexName="test_FLAGSHIP_ECOM_recommend"
+    >
+      <Configure hitsPerPage={18} />
+      <div className="search-panel">
+        <div className="search-panel__results">
+          <SearchBox
+            className="searchbox"
+            translations={{
+              placeholder: 'Search for articles like "dress" or "jeans"',
+            }}
+          />
+          <InjectedInfiniteHits
+            slots={() => [
+              {
+                injectAt: 2,
+                slotComponent: RelatedProducts,
+              },
+            ]}
+            hitComponent={ProductHit}
+          />
+        </div>
+      </div>
+    </InstantSearch>
+  );
+}
+
+function RelatedProducts({ resultsByIndex }) {
+  const { recommendations } = useFrequentlyBoughtTogether({
+    recommendClient,
+    indexName: 'test_FLAGSHIP_ECOM_recommend',
+    objectIDs: resultsByIndex.test_FLAGSHIP_ECOM_recommend.hits
+      .slice(0, 2)
+      .map(({ objectID }) => objectID),
+    maxRecommendations: 2,
+  });
+
+  return (
+    <article className="Recommend Block-1/2 sm:Block-full">
+      <h2>Frequently bought together</h2>
+      <ul>
+        {recommendations.map(recommendation => (
+          <li key={recommendation.objectID}>
+            <ProductHit hit={recommendation} />
+          </li>
+        ))}
+      </ul>
+    </article>
+  );
+}
+
+function ProductHit({ hit }) {
+  return (
+    <article
+      style={{
+        display: 'flex',
+        height: '100%',
+        flexDirection: 'column',
+        justifyContent: 'space-around',
+      }}
+    >
+      <img
+        src={hit.image_urls[0]}
+        alt={hit.name}
+        style={{
+          width: '100%',
+          objectFit: 'contain',
+        }}
+      />
+      <p style={{ marginBottom: 0 }}>
+        <Highlight attribute="name" hit={hit} />
+      </p>
+    </article>
+  );
+}

--- a/React InstantSearch/injected-content/src/pages/Recommend.js
+++ b/React InstantSearch/injected-content/src/pages/Recommend.js
@@ -35,13 +35,13 @@ export function Recommend() {
           <SearchBox
             className="searchbox"
             translations={{
-              placeholder: 'Search for articles like "dress" or "jeans"',
+              placeholder: 'Search for articles like "dress" or "jacket"',
             }}
           />
           <InjectedInfiniteHits
             slots={() => [
               {
-                injectAt: 1,
+                injectAt: 5,
                 slotComponent: RelatedProducts,
               },
             ]}
@@ -57,9 +57,7 @@ function RelatedProducts({ resultsByIndex }) {
   const { recommendations } = useFrequentlyBoughtTogether({
     recommendClient,
     indexName: 'test_FLAGSHIP_ECOM_recommend',
-    objectIDs: resultsByIndex.test_FLAGSHIP_ECOM_recommend.hits
-      .slice(0, 1)
-      .map(({ objectID }) => objectID),
+    objectIDs: [resultsByIndex.test_FLAGSHIP_ECOM_recommend.hits[4].objectID],
     maxRecommendations: 3,
   });
 

--- a/React InstantSearch/injected-content/src/pages/Recommend.js
+++ b/React InstantSearch/injected-content/src/pages/Recommend.js
@@ -29,7 +29,7 @@ export function Recommend() {
       searchClient={searchClient}
       indexName="test_FLAGSHIP_ECOM_recommend"
     >
-      <Configure hitsPerPage={18} />
+      <Configure hitsPerPage={17} />
       <div className="search-panel">
         <div className="search-panel__results Recommend">
           <SearchBox
@@ -84,11 +84,14 @@ function ProductHit({ hit }) {
         display: 'flex',
         height: '100%',
         flexDirection: 'column',
-        justifyContent: 'space-around',
+        justifyContent: 'space-between',
       }}
     >
       <div
         style={{
+          margin: '0 auto',
+          maxWidth: '100%',
+          maxHeight: '200px',
           aspectRatio: '9/10',
           overflow: 'hidden',
         }}

--- a/React InstantSearch/injected-content/src/pages/Recommend.js
+++ b/React InstantSearch/injected-content/src/pages/Recommend.js
@@ -31,7 +31,7 @@ export function Recommend() {
     >
       <Configure hitsPerPage={18} />
       <div className="search-panel">
-        <div className="search-panel__results">
+        <div className="search-panel__results Recommend">
           <SearchBox
             className="searchbox"
             translations={{
@@ -41,7 +41,7 @@ export function Recommend() {
           <InjectedInfiniteHits
             slots={() => [
               {
-                injectAt: 2,
+                injectAt: 1,
                 slotComponent: RelatedProducts,
               },
             ]}
@@ -58,13 +58,13 @@ function RelatedProducts({ resultsByIndex }) {
     recommendClient,
     indexName: 'test_FLAGSHIP_ECOM_recommend',
     objectIDs: resultsByIndex.test_FLAGSHIP_ECOM_recommend.hits
-      .slice(0, 2)
+      .slice(0, 1)
       .map(({ objectID }) => objectID),
-    maxRecommendations: 2,
+    maxRecommendations: 3,
   });
 
   return (
-    <article className="Recommend Block-1/2 sm:Block-full">
+    <article className="FrequentlyBoughtTogether">
       <h2>Frequently bought together</h2>
       <ul>
         {recommendations.map(recommendation => (
@@ -87,14 +87,18 @@ function ProductHit({ hit }) {
         justifyContent: 'space-around',
       }}
     >
-      <img
-        src={hit.image_urls[0]}
-        alt={hit.name}
+      <div
         style={{
-          width: '100%',
-          objectFit: 'contain',
+          aspectRatio: '9/10',
+          overflow: 'hidden',
         }}
-      />
+      >
+        <img
+          src={hit.image_urls[0]}
+          alt={hit.name}
+          style={{ width: '100%', height: '100%', objectFit: 'contain' }}
+        />
+      </div>
       <p style={{ marginBottom: 0 }}>
         <Highlight attribute="name" hit={hit} />
       </p>

--- a/React InstantSearch/injected-content/src/routes.js
+++ b/React InstantSearch/injected-content/src/routes.js
@@ -1,6 +1,7 @@
 import { HitsFromIndex } from './pages/HitsFromIndex';
 import { HitsFromRule } from './pages/HitsFromRule';
 import { InterspersedHits } from './pages/InterspersedHits';
+import { Recommend } from './pages/Recommend';
 import { ThirdPartyHits } from './pages/ThirdPartyHits';
 
 export const routes = [
@@ -23,5 +24,10 @@ export const routes = [
     path: '/interspersed',
     label: 'Interspersed hits',
     element: InterspersedHits,
+  },
+  {
+    path: '/recommend',
+    label: 'Recommend',
+    element: Recommend,
   },
 ];

--- a/React InstantSearch/injected-content/yarn.lock
+++ b/React InstantSearch/injected-content/yarn.lock
@@ -83,6 +83,42 @@
   dependencies:
     "@algolia/logger-common" "4.12.0"
 
+"@algolia/recommend-core@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@algolia/recommend-core/-/recommend-core-1.1.0.tgz#e35bd11a0fb0094df2f5b4e3c8c0942a7553f5fc"
+  integrity sha512-iX8nedpDT4zQjTJAsFo0uc+pQAmuHb/TCY9dIyFGS+L6GqBvovcViDWQobF48IFvbYV0OSMANeQj8RIqBJ7Rrg==
+
+"@algolia/recommend-react@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@algolia/recommend-react/-/recommend-react-1.1.0.tgz#9f1799e0e89b79cd465ed5945ba4b27da86258f0"
+  integrity sha512-x44opUZVdgGm3algt3x/pxgvAUsye986YN0z4cSEymjyma5vv75w3bknqPLNsTaTvh61dhFXEY1rfTsaLyOdMg==
+  dependencies:
+    "@algolia/recommend-core" "1.1.0"
+    "@algolia/recommend-vdom" "1.1.0"
+    dequal "^2.0.0"
+
+"@algolia/recommend-vdom@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@algolia/recommend-vdom/-/recommend-vdom-1.1.0.tgz#55c02857c9aa85ef01640143e525594c77aaeebe"
+  integrity sha512-Gsd9tOaRfVhdlQRGLzXwSvddRdVyzp8s/3h9Tb448Aa6lUVT/3SUbP5ODFX9TOtb6RtOGWQl8nT6nhgpPgJ4zA==
+
+"@algolia/recommend@4.12.0":
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/@algolia/recommend/-/recommend-4.12.0.tgz#b29a847ca25e2e72abfc367ab69c5f7ab4199c9d"
+  integrity sha512-gArGBRzcvWee+MrnSbZQOBxfH3r8kGOYsonoSH/+TQ0VODrkCF/ZChWNLAwe5Zr/SSxSex+WPwI5PxrgSUusMQ==
+  dependencies:
+    "@algolia/cache-browser-local-storage" "4.12.0"
+    "@algolia/cache-common" "4.12.0"
+    "@algolia/cache-in-memory" "4.12.0"
+    "@algolia/client-common" "4.12.0"
+    "@algolia/client-search" "4.12.0"
+    "@algolia/logger-common" "4.12.0"
+    "@algolia/logger-console" "4.12.0"
+    "@algolia/requester-browser-xhr" "4.12.0"
+    "@algolia/requester-common" "4.12.0"
+    "@algolia/requester-node-http" "4.12.0"
+    "@algolia/transporter" "4.12.0"
+
 "@algolia/requester-browser-xhr@4.12.0":
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.12.0.tgz#64e8e4d4f0724e477421454215195400351cfe61"
@@ -3547,6 +3583,11 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+dequal@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
 
 des.js@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This adds a **Recommend** page to the injected-content code sample, that will be used to illustrate a new in-depth section in the [**Injecting content between hits**](https://github.com/algolia/doc/pull/6541) guide.

[**Preview →**](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/feat/injected-content-recommend/React%20InstantSearch/injected-content?file=/src/pages/Recommend.js)

![injecting-content-recommend](https://user-images.githubusercontent.com/154633/149916112-4c6295a5-e4bb-4ed9-84fa-541f3c81c6da.jpg)

