### PR TITLE
Updated the Vue IS geosearch demo to use the latest version

### DIFF
--- a/Vue InstantSearch/geo-search/package.json
+++ b/Vue InstantSearch/geo-search/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "infinite-scroll",
+  "name": "geosearch-with-googlemaps",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -12,7 +12,7 @@
     "instantsearch.css": "7.3.1",
     "vue": "2.6.10",
     "vue-googlemaps": "0.1.2",
-    "vue-instantsearch": "3.8.1"
+    "vue-instantsearch": "latest"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "3.6.0",

--- a/Vue InstantSearch/geo-search/src/App.vue
+++ b/Vue InstantSearch/geo-search/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="root">
     <header class="header">
-      <h1 class="header-title"><a href="/">Vue InstantSearch v2 starter</a></h1>
+      <h1 class="header-title"><a href="/">Geo-search example with Vue InstantSearch and Google Maps</a></h1>
       <p class="header-subtitle">
         using
         <a href="https://github.com/algolia/vue-instantsearch">


### PR DESCRIPTION
Previously it was running on Vue InstantSearch v3.x, and the showing in the demo's title v2. Removed that reference and bumped to the latest VueIS version. Bonus: fixed the name of the package.