### PR TITLE
updated import of algoliasearch to fix error

### DIFF
--- a/react-instantsearch-native/getting-started/App.js
+++ b/react-instantsearch-native/getting-started/App.js
@@ -6,7 +6,7 @@ import {
   StatusBar,
   Button,
 } from 'react-native';
-import algoliasearch from 'algoliasearch/reactnative';
+import algoliasearch from 'algoliasearch';
 import {
   InstantSearch,
   connectRefinementList,


### PR DESCRIPTION
expo snack link: https://snack.expo.dev/@git/github.com/algolia/doc-code-samples:React%20InstantSearch%20Native/getting-started  in algolia live demo https://www.algolia.com/doc/guides/building-search-ui/going-further/native/react/ is giving error on importing algoliasearch. 

changing line to import algoliasearch from 'algoliasearch' works.