### PR TITLE
fix(metadata): implement `$$widgetType` for Facet Dropdown with RISH

### DIFF
--- a/react-instantsearch-hooks/facet-dropdown/src/components/FacetDropdown.tsx
+++ b/react-instantsearch-hooks/facet-dropdown/src/components/FacetDropdown.tsx
@@ -89,7 +89,10 @@ export function FacetDropdown({
   classNames = {},
 }: DropdownProps) {
   const { results, uiState } = useInstantSearch();
-  const { items } = useCurrentRefinements();
+  const { items } = useCurrentRefinements(
+    {},
+    { $$widgetType: 'cmty.facetDropdown' }
+  );
   const [isOpened, setIsOpened] = useState(false);
   const panelRef = useRef(null);
 


### PR DESCRIPTION
This PR implements `$$widgetType` to the `FacetDropdown` widget for RISH.