### PR TITLE
fix(metadata): implement `$$widgetType` for Facet Dropdown with IS.js

### DIFF
--- a/instantsearch.js/facet-dropdown/src/Dropdown.js
+++ b/instantsearch.js/facet-dropdown/src/Dropdown.js
@@ -85,6 +85,7 @@ export function createDropdown(
     // Return a modified version of the widget
     return {
       ...widget,
+      $$widgetType: 'cmty.facetDropdown',
       init: (options) => {
         const rootElem = document
           .querySelector(widgetParams.container)


### PR DESCRIPTION
This PR implements `$$widgetType` to the FacetDropdown widget for IS.js