### PR TITLE
fix(js): call `start` on correct object

### DIFF
--- a/instantsearch.js/multi-index-hits/src/app.js
+++ b/instantsearch.js/multi-index-hits/src/app.js
@@ -20,7 +20,8 @@ search.addWidgets([
   instantsearch.widgets.hits({
     container: '#hits-instant-search',
     templates: {
-      item: '{{#helpers.highlight}}{ "attribute": "name" }{{/helpers.highlight}}',
+      item:
+        '{{#helpers.highlight}}{ "attribute": "name" }{{/helpers.highlight}}',
     },
   }),
   instantsearch.widgets
@@ -32,10 +33,11 @@ search.addWidgets([
       instantsearch.widgets.hits({
         container: '#hits-instant-search-price-desc',
         templates: {
-          item: '{{#helpers.highlight}}{ "attribute": "name" }{{/helpers.highlight}}',
+          item:
+            '{{#helpers.highlight}}{ "attribute": "name" }{{/helpers.highlight}}',
         },
       }),
     ]),
 ]);
 
-start.start();
+search.start();


### PR DESCRIPTION
A bug sneaked into #408 causing the example to no longer work.

This fixes it by calling the `start` function on the right object.

In the future, we could fix this by using TypeScript as much as possible, and testing examples.