### PR TITLE
fix(hooks): add and set up TypeScript

### DIFF
--- a/react-instantsearch-hooks/query-suggestions/package.json
+++ b/react-instantsearch-hooks/query-suggestions/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@types/react": "17.0.45",
-    "parcel": "2.5.0"
+    "parcel": "2.5.0",
+    "typescript": "4.8.4"
   }
 }

--- a/react-instantsearch-hooks/query-suggestions/tsconfig.json
+++ b/react-instantsearch-hooks/query-suggestions/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/*"]
+}

--- a/react-instantsearch-hooks/query-suggestions/tsconfig.json
+++ b/react-instantsearch-hooks/query-suggestions/tsconfig.json
@@ -5,7 +5,9 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
   },
   "include": ["src/*"]
 }

--- a/react-instantsearch-hooks/query-suggestions/yarn.lock
+++ b/react-instantsearch-hooks/query-suggestions/yarn.lock
@@ -1688,6 +1688,11 @@ type-fest@^0.20.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
+typescript@4.8.4:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
+  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+
 update-browserslist-db@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.4.tgz#dbfc5a789caa26b1db8990796c2c8ebbce304824"


### PR DESCRIPTION
The [Query Suggestions](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch-hooks/query-suggestions) example fails on CodeSandbox because of the `import type` statement and the fact that we don't import React in TSX files.

TypeScript is actually missing from dependencies and there is no `tsconfig.json` file. This PR adds them to fix the problems.