### PR TITLE
fix(nuxt): bump nuxt version to fix issue on CodeSandbox

### DIFF
--- a/vue-instantsearch/nuxt/package.json
+++ b/vue-instantsearch/nuxt/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "algoliasearch": "4.12.1",
     "cross-env": "^5.2.0",
-    "nuxt": "^2.4.5",
+    "nuxt": "^2.15.8",
     "vue-instantsearch": "4.1.1",
     "vue-server-renderer": "2.6.11"
   },


### PR DESCRIPTION
### [CR-2350](https://algolia.atlassian.net/browse/CR-2350)

Currently [the nuxt example does not work on CodeSandbox](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/nuxt), we get an error saying the container does not have enough available space.

Seems like just bumping the version of nuxt does the trick, it probably generates less stuff inside the `.nuxt` folder ?

[Branch preview on CodeSandbox](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix/vue-nuxt-bump-dependency/vue-instantsearch/nuxt)

