### PR TITLE
fix(instantsearch.js/facet-dropdown): use render instead of init

### DIFF
--- a/instantsearch.js/facet-dropdown/index.html
+++ b/instantsearch.js/facet-dropdown/index.html
@@ -50,8 +50,8 @@
       <div id="pagination"></div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/algoliasearch/3.32.0/algoliasearchLite.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@4.9.1"></script>
+    <script src="https://cdn.jsdelivr.net/npm/algoliasearch@4/dist/algoliasearch-lite.umd.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@4"></script>
     <script src="./src/app.js"></script>
   </body>
 </html>

--- a/instantsearch.js/facet-dropdown/src/app.js
+++ b/instantsearch.js/facet-dropdown/src/app.js
@@ -15,7 +15,6 @@ const search = instantsearch({
 const MOBILE_WIDTH = 375;
 
 const brandDropdown = createDropdown(instantsearch.widgets.refinementList, {
-  // closeOnChange: true,
   closeOnChange: () => window.innerWidth >= MOBILE_WIDTH,
   cssClasses: { root: 'my-BrandDropdown' },
 });
@@ -23,7 +22,6 @@ const brandDropdown = createDropdown(instantsearch.widgets.refinementList, {
 const refinementListDropdown = createDropdown(
   instantsearch.widgets.refinementList,
   {
-    // closeOnChange: true,
     closeOnChange: () => window.innerWidth >= MOBILE_WIDTH,
   }
 );
@@ -44,13 +42,13 @@ const priceDropdown = createDropdown(instantsearch.widgets.rangeSlider, {
 const priceMenuDropdown = createDropdown(instantsearch.widgets.numericMenu, {
   buttonText({ items }) {
     const refinedItem = (items || []).find(
-      (item) => item.label !== 'All' && item.isRefined
+      item => item.label !== 'All' && item.isRefined
     );
     return refinedItem ? `Price (${refinedItem.label})` : 'Price Menu';
   },
   buttonClassName({ items }) {
     const isRefined = (items || []).find(
-      (item) => item.label !== 'All' && item.isRefined
+      item => item.label !== 'All' && item.isRefined
     );
     return isRefined && 'ais-Dropdown-button--refined';
   },


### PR DESCRIPTION
This fixes an issue that was introduced by a change in InstantSearch.js in [v4.29.0](https://github.com/algolia/instantsearch.js/compare/v4.28.0...v4.29.0) (see [pull request](https://github.com/algolia/instantsearch/pull/4845)). On `init`, the panel's templates aren't rendered yet, so I'm now using `render` instead.

This demo could use a little bit of extra refactoring, but for the sake of legibility, I kept the changes as minimal as possible.

Related Jira ticket: https://algolia.atlassian.net/browse/CR-2851
fixes #422