### PR TITLE
chore: add codesandbox link to all code samples

### DIFF
--- a/angular-instantsearch/algolia-insights/README.md
+++ b/angular-instantsearch/algolia-insights/README.md
@@ -1,6 +1,6 @@
 # algolia-insights
 
-[![Edit algolia-insights](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/algolia-insights)
+[![Edit algolia-insights](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/algolia/doc-code-samples/tree/master/angular-instantsearch/algolia-insights)
 
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 

--- a/angular-instantsearch/algolia-insights/README.md
+++ b/angular-instantsearch/algolia-insights/README.md
@@ -1,5 +1,7 @@
 # algolia-insights
 
+[![Edit algolia-insights](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/algolia-insights)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/angular-instantsearch/algolia-insights/angular.json
+++ b/angular-instantsearch/algolia-insights/angular.json
@@ -71,7 +71,8 @@
               "browserTarget": "algolia-insights:build:production"
             },
             "development": {
-              "browserTarget": "algolia-insights:build:development"
+              "browserTarget": "algolia-insights:build:development",
+              "disableHostCheck": true
             }
           },
           "defaultConfiguration": "development"

--- a/angular-instantsearch/autocomplete-results-page/README.md
+++ b/angular-instantsearch/autocomplete-results-page/README.md
@@ -1,5 +1,7 @@
 # autocomplete-results-page
 
+[![Edit autocomplete-results-page](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/autocomplete-results-page)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/angular-instantsearch/autocomplete-results-page/README.md
+++ b/angular-instantsearch/autocomplete-results-page/README.md
@@ -1,6 +1,6 @@
 # autocomplete-results-page
 
-[![Edit autocomplete-results-page](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/autocomplete-results-page)
+[![Edit autocomplete-results-page](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/algolia/doc-code-samples/tree/master/angular-instantsearch/autocomplete-results-page)
 
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 

--- a/angular-instantsearch/autocomplete-results-page/angular.json
+++ b/angular-instantsearch/autocomplete-results-page/angular.json
@@ -72,7 +72,8 @@
               "browserTarget": "autocomplete-results-page:build:production"
             },
             "development": {
-              "browserTarget": "autocomplete-results-page:build:development"
+              "browserTarget": "autocomplete-results-page:build:development",
+              "disableHostCheck": true
             }
           },
           "defaultConfiguration": "development"

--- a/angular-instantsearch/conditional-request/README.md
+++ b/angular-instantsearch/conditional-request/README.md
@@ -1,5 +1,7 @@
 # conditional-request
 
+[![Edit conditional-request](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/conditional-request)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/angular-instantsearch/conditional-request/README.md
+++ b/angular-instantsearch/conditional-request/README.md
@@ -1,6 +1,6 @@
 # conditional-request
 
-[![Edit conditional-request](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/conditional-request)
+[![Edit conditional-request](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/algolia/doc-code-samples/tree/master/angular-instantsearch/conditional-request)
 
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 

--- a/angular-instantsearch/conditional-request/angular.json
+++ b/angular-instantsearch/conditional-request/angular.json
@@ -71,7 +71,8 @@
               "browserTarget": "conditional-request:build:production"
             },
             "development": {
-              "browserTarget": "conditional-request:build:development"
+              "browserTarget": "conditional-request:build:development",
+              "disableHostCheck": true
             }
           },
           "defaultConfiguration": "development"

--- a/angular-instantsearch/debounced-search-box/README.md
+++ b/angular-instantsearch/debounced-search-box/README.md
@@ -1,6 +1,6 @@
 # debounced-search-box
 
-[![Edit debounced-search-box](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/debounced-search-box)
+[![Edit debounced-search-box](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/algolia/doc-code-samples/tree/master/angular-instantsearch/debounced-search-box)
 
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 

--- a/angular-instantsearch/debounced-search-box/README.md
+++ b/angular-instantsearch/debounced-search-box/README.md
@@ -1,5 +1,7 @@
 # debounced-search-box
 
+[![Edit debounced-search-box](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/debounced-search-box)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/angular-instantsearch/debounced-search-box/angular.json
+++ b/angular-instantsearch/debounced-search-box/angular.json
@@ -66,7 +66,8 @@
               "browserTarget": "debounced-search-box:build:production"
             },
             "development": {
-              "browserTarget": "debounced-search-box:build:development"
+              "browserTarget": "debounced-search-box:build:development",
+              "disableHostCheck": true
             }
           },
           "defaultConfiguration": "development"

--- a/angular-instantsearch/e-commerce/README.md
+++ b/angular-instantsearch/e-commerce/README.md
@@ -1,6 +1,6 @@
 # Angular Instantsearch e-commerce sample
 
-[![Edit e-commerce](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/e-commerce)
+[![Edit e-commerce](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/algolia/doc-code-samples/tree/master/angular-instantsearch/e-commerce)
 
 Also available in [InstantSearch.js](../../instantsearch.js/e-commerce/), [React InstantSearch](../../react-instantsearch/e-commerce/) and [Vue InstantSearch](../../vue-instantsearch/e-commerce/)
 

--- a/angular-instantsearch/e-commerce/README.md
+++ b/angular-instantsearch/e-commerce/README.md
@@ -1,5 +1,7 @@
 # Angular Instantsearch e-commerce sample
 
+[![Edit e-commerce](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/e-commerce)
+
 Also available in [InstantSearch.js](../../instantsearch.js/e-commerce/), [React InstantSearch](../../react-instantsearch/e-commerce/) and [Vue InstantSearch](../../vue-instantsearch/e-commerce/)
 
 ---

--- a/angular-instantsearch/e-commerce/angular.json
+++ b/angular-instantsearch/e-commerce/angular.json
@@ -70,7 +70,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "e-commerce:build"
+            "browserTarget": "e-commerce:build",
+            "disableHostCheck": true
           },
           "configurations": {
             "production": {

--- a/angular-instantsearch/extending-widgets/README.md
+++ b/angular-instantsearch/extending-widgets/README.md
@@ -1,5 +1,7 @@
 # extending-widgets
 
+[![Edit extending-widgets](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/extending-widgets)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/angular-instantsearch/extending-widgets/README.md
+++ b/angular-instantsearch/extending-widgets/README.md
@@ -1,6 +1,6 @@
 # extending-widgets
 
-[![Edit extending-widgets](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/extending-widgets)
+[![Edit extending-widgets](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/algolia/doc-code-samples/tree/master/angular-instantsearch/extending-widgets)
 
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 

--- a/angular-instantsearch/extending-widgets/angular.json
+++ b/angular-instantsearch/extending-widgets/angular.json
@@ -71,7 +71,8 @@
               "browserTarget": "extending-widgets:build:production"
             },
             "development": {
-              "browserTarget": "extending-widgets:build:development"
+              "browserTarget": "extending-widgets:build:development",
+              "disableHostCheck": true
             }
           },
           "defaultConfiguration": "development"

--- a/angular-instantsearch/geo-search/README.md
+++ b/angular-instantsearch/geo-search/README.md
@@ -1,6 +1,6 @@
 # geo-search
 
-[![Edit geo-search](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/geo-search)
+[![Edit geo-search](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/algolia/doc-code-samples/tree/master/angular-instantsearch/geo-search)
 
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 

--- a/angular-instantsearch/geo-search/README.md
+++ b/angular-instantsearch/geo-search/README.md
@@ -1,5 +1,7 @@
 # geo-search
 
+[![Edit geo-search](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/geo-search)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/angular-instantsearch/geo-search/angular.json
+++ b/angular-instantsearch/geo-search/angular.json
@@ -71,7 +71,8 @@
               "browserTarget": "geo-search:build:production"
             },
             "development": {
-              "browserTarget": "geo-search:build:development"
+              "browserTarget": "geo-search:build:development",
+              "disableHostCheck": true
             }
           },
           "defaultConfiguration": "development"

--- a/angular-instantsearch/getting-started/README.md
+++ b/angular-instantsearch/getting-started/README.md
@@ -1,5 +1,7 @@
 # getting-started
 
+[![Edit getting-started](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/getting-started)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/angular-instantsearch/getting-started/README.md
+++ b/angular-instantsearch/getting-started/README.md
@@ -1,6 +1,6 @@
 # getting-started
 
-[![Edit getting-started](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/getting-started)
+[![Edit getting-started](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/algolia/doc-code-samples/tree/master/angular-instantsearch/getting-started)
 
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 

--- a/angular-instantsearch/getting-started/angular.json
+++ b/angular-instantsearch/getting-started/angular.json
@@ -71,7 +71,8 @@
               "browserTarget": "getting-started:build:production"
             },
             "development": {
-              "browserTarget": "getting-started:build:development"
+              "browserTarget": "getting-started:build:development",
+              "disableHostCheck": true
             }
           },
           "defaultConfiguration": "development"

--- a/angular-instantsearch/infinite-scroll/README.md
+++ b/angular-instantsearch/infinite-scroll/README.md
@@ -1,6 +1,6 @@
 # infinite-scroll
 
-[![Edit infinite-scroll](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/infinite-scroll)
+[![Edit infinite-scroll](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/algolia/doc-code-samples/tree/master/angular-instantsearch/infinite-scroll)
 
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 

--- a/angular-instantsearch/infinite-scroll/README.md
+++ b/angular-instantsearch/infinite-scroll/README.md
@@ -1,5 +1,7 @@
 # infinite-scroll
 
+[![Edit infinite-scroll](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/infinite-scroll)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/angular-instantsearch/infinite-scroll/angular.json
+++ b/angular-instantsearch/infinite-scroll/angular.json
@@ -71,7 +71,8 @@
               "browserTarget": "infinite-scroll:build:production"
             },
             "development": {
-              "browserTarget": "infinite-scroll:build:development"
+              "browserTarget": "infinite-scroll:build:development",
+              "disableHostCheck": true
             }
           },
           "defaultConfiguration": "development"

--- a/angular-instantsearch/loading-indicator/README.md
+++ b/angular-instantsearch/loading-indicator/README.md
@@ -1,6 +1,6 @@
 # loading-indicator
 
-[![Edit loading-indicator](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/loading-indicator)
+[![Edit loading-indicator](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/algolia/doc-code-samples/tree/master/angular-instantsearch/loading-indicator)
 
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 

--- a/angular-instantsearch/loading-indicator/README.md
+++ b/angular-instantsearch/loading-indicator/README.md
@@ -1,5 +1,7 @@
 # loading-indicator
 
+[![Edit loading-indicator](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/loading-indicator)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/angular-instantsearch/loading-indicator/angular.json
+++ b/angular-instantsearch/loading-indicator/angular.json
@@ -71,7 +71,8 @@
               "browserTarget": "loading-indicator:build:production"
             },
             "development": {
-              "browserTarget": "loading-indicator:build:development"
+              "browserTarget": "loading-indicator:build:development",
+              "disableHostCheck": true
             }
           },
           "defaultConfiguration": "development"

--- a/angular-instantsearch/media/README.md
+++ b/angular-instantsearch/media/README.md
@@ -1,5 +1,7 @@
 # Angular Instantsearch media sample
 
+[![Edit media](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/media)
+
 Also available in [InstantSearch.js](../../instantsearch.js/media/), [React InstantSearch](../../react-instantsearch/media/) and [Vue InstantSearch](../../vue-instantsearch/media/)
 
 ---

--- a/angular-instantsearch/media/README.md
+++ b/angular-instantsearch/media/README.md
@@ -1,6 +1,6 @@
 # Angular Instantsearch media sample
 
-[![Edit media](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/media)
+[![Edit media](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/algolia/doc-code-samples/tree/master/angular-instantsearch/media)
 
 Also available in [InstantSearch.js](../../instantsearch.js/media/), [React InstantSearch](../../react-instantsearch/media/) and [Vue InstantSearch](../../vue-instantsearch/media/)
 

--- a/angular-instantsearch/media/angular.json
+++ b/angular-instantsearch/media/angular.json
@@ -55,7 +55,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "e-commerce:build"
+            "browserTarget": "e-commerce:build",
+            "disableHostCheck": true
           },
           "configurations": {
             "production": {

--- a/angular-instantsearch/multi-index-autocomplete/README.md
+++ b/angular-instantsearch/multi-index-autocomplete/README.md
@@ -1,5 +1,7 @@
 # multi-index-autocomplete
 
+[![Edit multi-index-autocomplete](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/multi-index-autocomplete)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/angular-instantsearch/multi-index-autocomplete/README.md
+++ b/angular-instantsearch/multi-index-autocomplete/README.md
@@ -1,6 +1,6 @@
 # multi-index-autocomplete
 
-[![Edit multi-index-autocomplete](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/multi-index-autocomplete)
+[![Edit multi-index-autocomplete](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/algolia/doc-code-samples/tree/master/angular-instantsearch/multi-index-autocomplete)
 
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 

--- a/angular-instantsearch/multi-index-autocomplete/angular.json
+++ b/angular-instantsearch/multi-index-autocomplete/angular.json
@@ -72,7 +72,8 @@
               "browserTarget": "multi-index-autocomplete:build:production"
             },
             "development": {
-              "browserTarget": "multi-index-autocomplete:build:development"
+              "browserTarget": "multi-index-autocomplete:build:development",
+              "disableHostCheck": true
             }
           },
           "defaultConfiguration": "development"

--- a/angular-instantsearch/multi-index-hits/README.md
+++ b/angular-instantsearch/multi-index-hits/README.md
@@ -1,6 +1,6 @@
 # multi-index-hits
 
-[![Edit multi-index-hits](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/multi-index-hits)
+[![Edit multi-index-hits](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/algolia/doc-code-samples/tree/master/angular-instantsearch/multi-index-hits)
 
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 

--- a/angular-instantsearch/multi-index-hits/README.md
+++ b/angular-instantsearch/multi-index-hits/README.md
@@ -1,5 +1,7 @@
 # multi-index-hits
 
+[![Edit multi-index-hits](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/multi-index-hits)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/angular-instantsearch/multi-index-hits/angular.json
+++ b/angular-instantsearch/multi-index-hits/angular.json
@@ -71,7 +71,8 @@
               "browserTarget": "multi-index-hits:build:production"
             },
             "development": {
-              "browserTarget": "multi-index-hits:build:development"
+              "browserTarget": "multi-index-hits:build:development",
+              "disableHostCheck": true
             }
           },
           "defaultConfiguration": "development"

--- a/angular-instantsearch/query-suggestions/README.md
+++ b/angular-instantsearch/query-suggestions/README.md
@@ -1,6 +1,6 @@
 # query-suggestions
 
-[![Edit query-suggestions](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/query-suggestions)
+[![Edit query-suggestions](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/algolia/doc-code-samples/tree/master/angular-instantsearch/query-suggestions)
 
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 

--- a/angular-instantsearch/query-suggestions/README.md
+++ b/angular-instantsearch/query-suggestions/README.md
@@ -1,5 +1,7 @@
 # query-suggestions
 
+[![Edit query-suggestions](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/query-suggestions)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/angular-instantsearch/query-suggestions/angular.json
+++ b/angular-instantsearch/query-suggestions/angular.json
@@ -72,7 +72,8 @@
               "browserTarget": "query-suggestions:build:production"
             },
             "development": {
-              "browserTarget": "query-suggestions:build:development"
+              "browserTarget": "query-suggestions:build:development",
+              "disableHostCheck": true
             }
           },
           "defaultConfiguration": "development"

--- a/angular-instantsearch/refresh/README.md
+++ b/angular-instantsearch/refresh/README.md
@@ -1,5 +1,7 @@
 # refresh
 
+[![Edit refresh](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/refresh)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/angular-instantsearch/refresh/README.md
+++ b/angular-instantsearch/refresh/README.md
@@ -1,6 +1,6 @@
 # refresh
 
-[![Edit refresh](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/refresh)
+[![Edit refresh](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/algolia/doc-code-samples/tree/master/angular-instantsearch/refresh)
 
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 

--- a/angular-instantsearch/refresh/angular.json
+++ b/angular-instantsearch/refresh/angular.json
@@ -71,7 +71,8 @@
               "browserTarget": "refresh:build:production"
             },
             "development": {
-              "browserTarget": "refresh:build:development"
+              "browserTarget": "refresh:build:development",
+              "disableHostCheck": true
             }
           },
           "defaultConfiguration": "development"

--- a/angular-instantsearch/routing-basic/README.md
+++ b/angular-instantsearch/routing-basic/README.md
@@ -1,6 +1,6 @@
 # routing-basic
 
-[![Edit routing-basic](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/routing-basic)
+[![Edit routing-basic](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/algolia/doc-code-samples/tree/master/angular-instantsearch/routing-basic)
 
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 

--- a/angular-instantsearch/routing-basic/README.md
+++ b/angular-instantsearch/routing-basic/README.md
@@ -1,5 +1,7 @@
 # routing-basic
 
+[![Edit routing-basic](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/routing-basic)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/angular-instantsearch/routing-basic/angular.json
+++ b/angular-instantsearch/routing-basic/angular.json
@@ -71,7 +71,8 @@
               "browserTarget": "routing-basic:build:production"
             },
             "development": {
-              "browserTarget": "routing-basic:build:development"
+              "browserTarget": "routing-basic:build:development",
+              "disableHostCheck": true
             }
           },
           "defaultConfiguration": "development"

--- a/angular-instantsearch/routing-seo-friendly/README.md
+++ b/angular-instantsearch/routing-seo-friendly/README.md
@@ -1,5 +1,7 @@
 # routing-seo-friendly
 
+[![Edit routing-seo-friendly](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/routing-seo-friendly)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/angular-instantsearch/routing-seo-friendly/README.md
+++ b/angular-instantsearch/routing-seo-friendly/README.md
@@ -1,6 +1,6 @@
 # routing-seo-friendly
 
-[![Edit routing-seo-friendly](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/routing-seo-friendly)
+[![Edit routing-seo-friendly](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/algolia/doc-code-samples/tree/master/angular-instantsearch/routing-seo-friendly)
 
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 

--- a/angular-instantsearch/routing-seo-friendly/angular.json
+++ b/angular-instantsearch/routing-seo-friendly/angular.json
@@ -71,7 +71,8 @@
               "browserTarget": "routing-seo-friendly:build:production"
             },
             "development": {
-              "browserTarget": "routing-seo-friendly:build:development"
+              "browserTarget": "routing-seo-friendly:build:development",
+              "disableHostCheck": true
             }
           },
           "defaultConfiguration": "development"

--- a/angular-instantsearch/routing-state-mapping/README.md
+++ b/angular-instantsearch/routing-state-mapping/README.md
@@ -1,6 +1,6 @@
 # routing-state-mapping
 
-[![Edit routing-state-mapping](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/routing-state-mapping)
+[![Edit routing-state-mapping](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/algolia/doc-code-samples/tree/master/angular-instantsearch/routing-state-mapping)
 
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 

--- a/angular-instantsearch/routing-state-mapping/README.md
+++ b/angular-instantsearch/routing-state-mapping/README.md
@@ -1,5 +1,7 @@
 # routing-state-mapping
 
+[![Edit routing-state-mapping](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/routing-state-mapping)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/angular-instantsearch/routing-state-mapping/angular.json
+++ b/angular-instantsearch/routing-state-mapping/angular.json
@@ -71,7 +71,8 @@
               "browserTarget": "routing-state-mapping:build:production"
             },
             "development": {
-              "browserTarget": "routing-state-mapping:build:development"
+              "browserTarget": "routing-state-mapping:build:development",
+              "disableHostCheck": true
             }
           },
           "defaultConfiguration": "development"

--- a/angular-instantsearch/secured-api-keys/README.md
+++ b/angular-instantsearch/secured-api-keys/README.md
@@ -1,6 +1,6 @@
 # secured-api-keys
 
-[![Edit secured-api-keys](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/secured-api-keys)
+[![Edit secured-api-keys](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/github/algolia/doc-code-samples/tree/master/angular-instantsearch/secured-api-keys)
 
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 

--- a/angular-instantsearch/secured-api-keys/README.md
+++ b/angular-instantsearch/secured-api-keys/README.md
@@ -1,5 +1,7 @@
 # secured-api-keys
 
+[![Edit secured-api-keys](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/fix-angular-12/angular-instantsearch/secured-api-keys)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/angular-instantsearch/secured-api-keys/angular.json
+++ b/angular-instantsearch/secured-api-keys/angular.json
@@ -71,7 +71,8 @@
               "browserTarget": "secured-api-keys:build:production"
             },
             "development": {
-              "browserTarget": "secured-api-keys:build:development"
+              "browserTarget": "secured-api-keys:build:development",
+              "disableHostCheck": true
             }
           },
           "defaultConfiguration": "development"

--- a/instantsearch.js/algolia-insights/README.md
+++ b/instantsearch.js/algolia-insights/README.md
@@ -1,5 +1,7 @@
 # getting-started
 
+[![Edit algolia-insights](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/algolia-insights)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/instantsearch.js/autocomplete-results-page/README.md
+++ b/instantsearch.js/autocomplete-results-page/README.md
@@ -1,5 +1,7 @@
 # autocomplete-results-page
 
+[![Edit autocomplete-results-page](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/autocomplete-results-page)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/instantsearch.js/conditional-request/README.md
+++ b/instantsearch.js/conditional-request/README.md
@@ -1,5 +1,7 @@
 # conditional-request
 
+[![Edit conditional-request](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/conditional-request)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/instantsearch.js/e-commerce/README.md
+++ b/instantsearch.js/e-commerce/README.md
@@ -1,5 +1,7 @@
 # Instantsearch e-commerce sample
 
+[![Edit e-commerce](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/e-commerce)
+
 Also available in [React InstantSearch](../../react-instantsearch/e-commerce/), [Angular InstantSearch](../../angular-instantsearch/e-commerce/) and [Vue InstantSearch](../../vue-instantsearch/e-commerce/)
 
 ---

--- a/instantsearch.js/e-commerce/README.md
+++ b/instantsearch.js/e-commerce/README.md
@@ -1,6 +1,6 @@
 # Instantsearch e-commerce sample
 
-[![Edit e-commerce](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/e-commerce)
+[![Edit e-commerce](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/js/e-commerce)
 
 Also available in [React InstantSearch](../../react-instantsearch/e-commerce/), [Angular InstantSearch](../../angular-instantsearch/e-commerce/) and [Vue InstantSearch](../../vue-instantsearch/e-commerce/)
 

--- a/instantsearch.js/facet-dropdown/README.md
+++ b/instantsearch.js/facet-dropdown/README.md
@@ -1,5 +1,7 @@
 # instantsearch.js-app
 
+[![Edit facet-dropdown](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/facet-dropdown)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/instantsearch.js/geo-search-control/README.md
+++ b/instantsearch.js/geo-search-control/README.md
@@ -1,5 +1,7 @@
 # geo-search-control
 
+[![Edit geo-search-control](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/geo-search-control)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/instantsearch.js/geo-search-custom-marker/README.md
+++ b/instantsearch.js/geo-search-custom-marker/README.md
@@ -1,5 +1,7 @@
 # geo-search-custom-marker
 
+[![Edit geo-search-custom-marker](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/geo-search-custom-marker)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/instantsearch.js/geo-search-hits/README.md
+++ b/instantsearch.js/geo-search-hits/README.md
@@ -1,5 +1,7 @@
 # geo-search-hits
 
+[![Edit geo-search-hits](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/geo-search-hits)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/instantsearch.js/geo-search-tourism/README.md
+++ b/instantsearch.js/geo-search-tourism/README.md
@@ -1,5 +1,7 @@
 # Instantsearch tourism sample
 
+[![Edit geo-search-tourism](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/geo-search-tourism)
+
 Also available in [React InstantSearch](../../react-instantsearch/geo-search-tourism/)
 
 ---

--- a/instantsearch.js/getting-started/README.md
+++ b/instantsearch.js/getting-started/README.md
@@ -1,5 +1,7 @@
 # InstantSearch getting started sample
 
+[![Edit getting-started](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/getting-started)
+
 Also available in [React InstantSearch](../../react-instantsearch/getting-started/), [React InstantSearch Hooks](https://github.com/algolia/instantsearch/tree/master/examples/react-hooks/getting-started/), [Angular InstantSearch](../../angular-instantsearch/getting-started/) and [Vue InstantSearch](../../vue-instantsearch/getting-started/)
 
 ---

--- a/instantsearch.js/getting-started/README.md
+++ b/instantsearch.js/getting-started/README.md
@@ -1,6 +1,6 @@
 # InstantSearch getting started sample
 
-[![Edit getting-started](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/getting-started)
+[![Edit getting-started](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/js/getting-started)
 
 Also available in [React InstantSearch](../../react-instantsearch/getting-started/), [React InstantSearch Hooks](https://github.com/algolia/instantsearch/tree/master/examples/react-hooks/getting-started/), [Angular InstantSearch](../../angular-instantsearch/getting-started/) and [Vue InstantSearch](../../vue-instantsearch/getting-started/)
 

--- a/instantsearch.js/infinite-scroll/README.md
+++ b/instantsearch.js/infinite-scroll/README.md
@@ -1,5 +1,7 @@
 # infinite-scroll
 
+[![Edit infinite-scroll](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/infinite-scroll)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/instantsearch.js/media/README.md
+++ b/instantsearch.js/media/README.md
@@ -1,6 +1,6 @@
 # Instantsearch media sample
 
-[![Edit media](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/media)
+[![Edit media](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/js/media)
 
 Also available in [React InstantSearch](../../react-instantsearch/media/), [Angular InstantSearch](../../angular-instantsearch/media/) and [Vue InstantSearch](../../vue-instantsearch/media/)
 

--- a/instantsearch.js/media/README.md
+++ b/instantsearch.js/media/README.md
@@ -1,5 +1,7 @@
 # Instantsearch media sample
 
+[![Edit media](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/media)
+
 Also available in [React InstantSearch](../../react-instantsearch/media/), [Angular InstantSearch](../../angular-instantsearch/media/) and [Vue InstantSearch](../../vue-instantsearch/media/)
 
 ---

--- a/instantsearch.js/multi-index-autocomplete/README.md
+++ b/instantsearch.js/multi-index-autocomplete/README.md
@@ -1,5 +1,7 @@
 # multi-index-autocomplete
 
+[![Edit multi-index-autocomplete](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/multi-index-autocomplete)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/instantsearch.js/multi-index-hits/README.md
+++ b/instantsearch.js/multi-index-hits/README.md
@@ -1,5 +1,7 @@
 # multi-index-hits
 
+[![Edit multi-index-hits](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/multi-index-hits)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/instantsearch.js/places/README.md
+++ b/instantsearch.js/places/README.md
@@ -1,3 +1,5 @@
 # Places sample
 
+[![Edit places](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/places)
+
 Places is no longer available. [Read our blog post announcement](https://www.algolia.com/blog/product/sunsetting-our-places-feature/) for more information, and alternatives.

--- a/instantsearch.js/places/README.md
+++ b/instantsearch.js/places/README.md
@@ -1,5 +1,3 @@
 # Places sample
 
-[![Edit places](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/places)
-
 Places is no longer available. [Read our blog post announcement](https://www.algolia.com/blog/product/sunsetting-our-places-feature/) for more information, and alternatives.

--- a/instantsearch.js/query-suggestions/README.md
+++ b/instantsearch.js/query-suggestions/README.md
@@ -1,5 +1,7 @@
 # query-suggestions
 
+[![Edit query-suggestions](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/query-suggestions)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/instantsearch.js/refresh-cache-periodically/README.md
+++ b/instantsearch.js/refresh-cache-periodically/README.md
@@ -1,5 +1,7 @@
 # refresh-cache-periodically
 
+[![Edit refresh-cache-periodically](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/refresh-cache-periodically)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/instantsearch.js/refresh-cache-user-action/README.md
+++ b/instantsearch.js/refresh-cache-user-action/README.md
@@ -1,5 +1,7 @@
 # refresh-cache-user-action
 
+[![Edit refresh-cache-user-action](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/refresh-cache-user-action)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/instantsearch.js/routing-basic/README.md
+++ b/instantsearch.js/routing-basic/README.md
@@ -1,5 +1,7 @@
 # routing-basic
 
+[![Edit routing-basic](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/routing-basic)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/instantsearch.js/routing-seo-friendly/README.md
+++ b/instantsearch.js/routing-seo-friendly/README.md
@@ -1,5 +1,7 @@
 # routing-seo-friendly
 
+[![Edit routing-seo-friendly](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/routing-seo-friendly)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/instantsearch.js/secured-api-keys/README.md
+++ b/instantsearch.js/secured-api-keys/README.md
@@ -1,5 +1,7 @@
 # secured-api-keys
 
+[![Edit secured-api-keys](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/secured-api-keys)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/instantsearch.js/segment-connector/README.md
+++ b/instantsearch.js/segment-connector/README.md
@@ -1,5 +1,7 @@
 # segment-connector
 
+[![Edit segment-connector](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/instantsearch.js/segment-connector)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch-hooks-native/getting-started/README.md
+++ b/react-instantsearch-hooks-native/getting-started/README.md
@@ -1,7 +1,5 @@
 # ais-ecommerce-demo-app
 
-[![Edit getting-started](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch-hooks-native/getting-started)
-
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch-hooks-native/getting-started/README.md
+++ b/react-instantsearch-hooks-native/getting-started/README.md
@@ -1,5 +1,7 @@
 # ais-ecommerce-demo-app
 
+[![Edit getting-started](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch-hooks-native/getting-started)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch-hooks/algolia-insights/README.md
+++ b/react-instantsearch-hooks/algolia-insights/README.md
@@ -1,5 +1,7 @@
 # algolia-insights
 
+[![Edit algolia-insights](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch-hooks/algolia-insights)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch-hooks/conditional-debouncing/README.md
+++ b/react-instantsearch-hooks/conditional-debouncing/README.md
@@ -1,5 +1,7 @@
 # conditional-debouncing
 
+[![Edit conditional-debouncing](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch-hooks/conditional-debouncing)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch-hooks/conditional-request/README.md
+++ b/react-instantsearch-hooks/conditional-request/README.md
@@ -1,5 +1,7 @@
 # conditional-request
 
+[![Edit conditional-request](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch-hooks/conditional-request)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch-hooks/facet-dropdown/README.md
+++ b/react-instantsearch-hooks/facet-dropdown/README.md
@@ -1,5 +1,7 @@
 # facet-dropdown
 
+[![Edit facet-dropdown](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch-hooks/facet-dropdown)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch-hooks/geo-search/README.md
+++ b/react-instantsearch-hooks/geo-search/README.md
@@ -1,5 +1,7 @@
 # geo-search
 
+[![Edit geo-search](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch-hooks/geo-search)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch-hooks/getting-started/README.md
+++ b/react-instantsearch-hooks/getting-started/README.md
@@ -1,5 +1,7 @@
 # React InstantSearch Hooks getting started sample
 
+[![Edit getting-started](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch-hooks/getting-started)
+
 Also available in [InstantSearch.js](../../instantsearch.js/getting-started/), [React InstantSearch](../../react-instantsearch/getting-started/), [Angular InstantSearch](../../angular-instantsearch/getting-started/) and [Vue InstantSearch](../../vue-instantsearch/getting-started/)
 
 ---

--- a/react-instantsearch-hooks/getting-started/README.md
+++ b/react-instantsearch-hooks/getting-started/README.md
@@ -1,6 +1,6 @@
 # React InstantSearch Hooks getting started sample
 
-[![Edit getting-started](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch-hooks/getting-started)
+[![Edit getting-started](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/react-hooks/getting-started)
 
 Also available in [InstantSearch.js](../../instantsearch.js/getting-started/), [React InstantSearch](../../react-instantsearch/getting-started/), [Angular InstantSearch](../../angular-instantsearch/getting-started/) and [Vue InstantSearch](../../vue-instantsearch/getting-started/)
 

--- a/react-instantsearch-hooks/multi-index-hits/README.md
+++ b/react-instantsearch-hooks/multi-index-hits/README.md
@@ -1,5 +1,7 @@
 # multi-index-hits
 
+[![Edit multi-index-hits](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch-hooks/multi-index-hits)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch-hooks/query-suggestions/README.md
+++ b/react-instantsearch-hooks/query-suggestions/README.md
@@ -1,5 +1,7 @@
 # query-suggestions
 
+[![Edit query-suggestions](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch-hooks/query-suggestions)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch-hooks/remix/README.md
+++ b/react-instantsearch-hooks/remix/README.md
@@ -1,5 +1,7 @@
 # Welcome to Remix!
 
+[![Edit remix](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch-hooks/remix)
+
 - [Remix Docs](https://remix.run/docs)
 
 ## Development

--- a/react-instantsearch-hooks/routing-basic/README.md
+++ b/react-instantsearch-hooks/routing-basic/README.md
@@ -1,5 +1,7 @@
 # routing-basic
 
+[![Edit routing-basic](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch-hooks/routing-basic)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch-hooks/routing-seo-friendly/README.md
+++ b/react-instantsearch-hooks/routing-seo-friendly/README.md
@@ -1,5 +1,7 @@
 # routing-seo-friendly
 
+[![Edit routing-seo-friendly](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch-hooks/routing-seo-friendly)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch-hooks/secured-api-keys/README.md
+++ b/react-instantsearch-hooks/secured-api-keys/README.md
@@ -1,5 +1,7 @@
 # secured-api-keys
 
+[![Edit secured-api-keys](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch-hooks/secured-api-keys)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch-native/getting-started/README.md
+++ b/react-instantsearch-native/getting-started/README.md
@@ -1,5 +1,7 @@
 # ais-ecommerce-demo-app
 
+[![Edit getting-started](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch-native/getting-started)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch-native/getting-started/README.md
+++ b/react-instantsearch-native/getting-started/README.md
@@ -1,7 +1,5 @@
 # ais-ecommerce-demo-app
 
-[![Edit getting-started](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch-native/getting-started)
-
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch/algolia-insights/README.md
+++ b/react-instantsearch/algolia-insights/README.md
@@ -1,5 +1,7 @@
 # getting-started
 
+[![Edit algolia-insights](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/algolia-insights)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch/autocomplete-mentions/README.md
+++ b/react-instantsearch/autocomplete-mentions/README.md
@@ -1,5 +1,7 @@
 # autocomplete-mentions
 
+[![Edit autocomplete-mentions](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/autocomplete-mentions)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch/autocomplete-results-page/README.md
+++ b/react-instantsearch/autocomplete-results-page/README.md
@@ -1,5 +1,7 @@
 # autocomplete-results-page
 
+[![Edit autocomplete-results-page](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/autocomplete-results-page)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch/conditional-request/README.md
+++ b/react-instantsearch/conditional-request/README.md
@@ -1,5 +1,7 @@
 # conditional-request
 
+[![Edit conditional-request](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/conditional-request)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch/e-commerce/README.md
+++ b/react-instantsearch/e-commerce/README.md
@@ -1,6 +1,6 @@
 # Instantsearch e-commerce sample
 
-[![Edit e-commerce](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/e-commerce)
+[![Edit e-commerce](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/react/e-commerce)
 
 Also available in [InstantSearch.js](../../instantsearch.js/e-commerce/), [Angular InstantSearch](../../angular-instantsearch/e-commerce/) and [Vue InstantSearch](../../vue-instantsearch/e-commerce/)
 

--- a/react-instantsearch/e-commerce/README.md
+++ b/react-instantsearch/e-commerce/README.md
@@ -1,5 +1,7 @@
 # Instantsearch e-commerce sample
 
+[![Edit e-commerce](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/e-commerce)
+
 Also available in [InstantSearch.js](../../instantsearch.js/e-commerce/), [Angular InstantSearch](../../angular-instantsearch/e-commerce/) and [Vue InstantSearch](../../vue-instantsearch/e-commerce/)
 
 ---

--- a/react-instantsearch/extending-widgets/README.md
+++ b/react-instantsearch/extending-widgets/README.md
@@ -1,5 +1,7 @@
 # extending-widgets
 
+[![Edit extending-widgets](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/extending-widgets)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch/geo-search-tourism/README.md
+++ b/react-instantsearch/geo-search-tourism/README.md
@@ -1,5 +1,7 @@
 # React Instantsearch tourism sample
 
+[![Edit geo-search-tourism](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/geo-search-tourism)
+
 Also available in [InstantSearch.js](../../instantsearch.js/geo-search-tourism/)
 
 ---

--- a/react-instantsearch/getting-started/README.md
+++ b/react-instantsearch/getting-started/README.md
@@ -1,6 +1,6 @@
 # React InstantSearch getting started sample
 
-[![Edit getting-started](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/getting-started)
+[![Edit getting-started](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/react/getting-started)
 
 Also available in [InstantSearch.js](../../instantsearch.js/getting-started/), [React InstantSearch Hooks](https://github.com/algolia/instantsearch/tree/master/examples/react-hooks/getting-started/), [Angular InstantSearch](../../angular-instantsearch/getting-started/) and [Vue InstantSearch](../../vue-instantsearch/getting-started/)
 

--- a/react-instantsearch/getting-started/README.md
+++ b/react-instantsearch/getting-started/README.md
@@ -1,5 +1,7 @@
 # React InstantSearch getting started sample
 
+[![Edit getting-started](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/getting-started)
+
 Also available in [InstantSearch.js](../../instantsearch.js/getting-started/), [React InstantSearch Hooks](https://github.com/algolia/instantsearch/tree/master/examples/react-hooks/getting-started/), [Angular InstantSearch](../../angular-instantsearch/getting-started/) and [Vue InstantSearch](../../vue-instantsearch/getting-started/)
 
 ---

--- a/react-instantsearch/infinite-scroll/README.md
+++ b/react-instantsearch/infinite-scroll/README.md
@@ -1,5 +1,7 @@
 # infinite-scroll
 
+[![Edit infinite-scroll](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/infinite-scroll)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch/injected-content/README.md
+++ b/react-instantsearch/injected-content/README.md
@@ -1,5 +1,7 @@
 # injected-content
 
+[![Edit injected-content](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/injected-content)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch/media/README.md
+++ b/react-instantsearch/media/README.md
@@ -1,5 +1,7 @@
 # React Instantsearch media sample
 
+[![Edit media](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/media)
+
 Also available in [InstantSearch](../../instantsearch.js/media/), [Angular InstantSearch](../../angular-instantsearch/media/) and [Vue InstantSearch](../../vue-instantsearch/media/)
 
 ---

--- a/react-instantsearch/media/README.md
+++ b/react-instantsearch/media/README.md
@@ -1,6 +1,6 @@
 # React Instantsearch media sample
 
-[![Edit media](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/media)
+[![Edit media](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/react/media)
 
 Also available in [InstantSearch](../../instantsearch.js/media/), [Angular InstantSearch](../../angular-instantsearch/media/) and [Vue InstantSearch](../../vue-instantsearch/media/)
 

--- a/react-instantsearch/multi-index-autocomplete/README.md
+++ b/react-instantsearch/multi-index-autocomplete/README.md
@@ -1,5 +1,7 @@
 # multi-index-autocomplete
 
+[![Edit multi-index-autocomplete](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/multi-index-autocomplete)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch/multi-index-hits/README.md
+++ b/react-instantsearch/multi-index-hits/README.md
@@ -1,5 +1,7 @@
 # multi-index-hits
 
+[![Edit multi-index-hits](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/multi-index-hits)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch/places/README.md
+++ b/react-instantsearch/places/README.md
@@ -1,3 +1,5 @@
 # Places sample
 
+[![Edit places](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/places)
+
 Places is no longer available. [Read our blog post announcement](https://www.algolia.com/blog/product/sunsetting-our-places-feature/) for more information, and alternatives.

--- a/react-instantsearch/places/README.md
+++ b/react-instantsearch/places/README.md
@@ -1,5 +1,3 @@
 # Places sample
 
-[![Edit places](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/places)
-
 Places is no longer available. [Read our blog post announcement](https://www.algolia.com/blog/product/sunsetting-our-places-feature/) for more information, and alternatives.

--- a/react-instantsearch/query-suggestions/README.md
+++ b/react-instantsearch/query-suggestions/README.md
@@ -1,5 +1,7 @@
 # react-querysuggestions
 
+[![Edit query-suggestions](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/query-suggestions)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch/routing-basic/README.md
+++ b/react-instantsearch/routing-basic/README.md
@@ -1,5 +1,7 @@
 # routing-basic
 
+[![Edit routing-basic](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/routing-basic)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch/routing-seo-friendly/README.md
+++ b/react-instantsearch/routing-seo-friendly/README.md
@@ -1,5 +1,7 @@
 # routing-basic
 
+[![Edit routing-seo-friendly](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/routing-seo-friendly)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch/routing-user-friendly/README.md
+++ b/react-instantsearch/routing-user-friendly/README.md
@@ -1,5 +1,7 @@
 # routing-basic
 
+[![Edit routing-user-friendly](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/routing-user-friendly)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/react-instantsearch/secured-api-keys/README.md
+++ b/react-instantsearch/secured-api-keys/README.md
@@ -1,5 +1,7 @@
 # secured-api-keys
 
+[![Edit secured-api-keys](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/react-instantsearch/secured-api-keys)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/vue-instantsearch/algolia-insights/README.md
+++ b/vue-instantsearch/algolia-insights/README.md
@@ -1,5 +1,7 @@
 # vue-instantsearch-v2-starter
 
+[![Edit algolia-insights](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/algolia-insights)
+
 ## Project setup
 ```
 yarn install

--- a/vue-instantsearch/autocomplete-results-page/README.md
+++ b/vue-instantsearch/autocomplete-results-page/README.md
@@ -1,5 +1,7 @@
 # vue-instantsearch-v2-starter
 
+[![Edit autocomplete-results-page](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/autocomplete-results-page)
+
 ## Project setup
 ```
 yarn install

--- a/vue-instantsearch/conditional-request/README.md
+++ b/vue-instantsearch/conditional-request/README.md
@@ -1,5 +1,7 @@
 # conditional-request
 
+[![Edit conditional-request](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/conditional-request)
+
 _This project was generated with [create-instantsearch-app](https://github.com/algolia/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started

--- a/vue-instantsearch/debounced-search-box/README.md
+++ b/vue-instantsearch/debounced-search-box/README.md
@@ -1,5 +1,7 @@
 # vue-instantsearch-v2-starter
 
+[![Edit debounced-search-box](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/debounced-search-box)
+
 ## Project setup
 ```
 yarn install

--- a/vue-instantsearch/e-commerce/README.md
+++ b/vue-instantsearch/e-commerce/README.md
@@ -1,5 +1,7 @@
 # Vue InstantSearch e-commerce sample
 
+[![Edit e-commerce](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/e-commerce)
+
 Also available in [InstantSearch.js](../../instantsearch.js/e-commerce/), [Angular InstantSearch](../../angular-instantsearch/e-commerce/) and [React InstantSearch](../../react-instantsearch/e-commerce/)
 
 ---

--- a/vue-instantsearch/e-commerce/README.md
+++ b/vue-instantsearch/e-commerce/README.md
@@ -1,6 +1,6 @@
 # Vue InstantSearch e-commerce sample
 
-[![Edit e-commerce](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/e-commerce)
+[![Edit e-commerce](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/vue/e-commerce)
 
 Also available in [InstantSearch.js](../../instantsearch.js/e-commerce/), [Angular InstantSearch](../../angular-instantsearch/e-commerce/) and [React InstantSearch](../../react-instantsearch/e-commerce/)
 

--- a/vue-instantsearch/extending-widgets/README.md
+++ b/vue-instantsearch/extending-widgets/README.md
@@ -1,5 +1,7 @@
 # vue-instantsearch-v2-starter
 
+[![Edit extending-widgets](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/extending-widgets)
+
 ## Project setup
 ```
 yarn install

--- a/vue-instantsearch/geo-search/README.md
+++ b/vue-instantsearch/geo-search/README.md
@@ -1,5 +1,7 @@
 # Geo-search example with Vue InstantSearch and Google Maps
 
+[![Edit geo-search](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/geo-search)
+
 This example shows you how to add Geo search capabilities to your Vue InstantSearch implementation and displaying the found results via Google Maps.
 
 <p align="center"><img src="capture.jpg" alt="A capture of the Geo-search example with Vue InstantSearch and Google Maps demo" /></p>

--- a/vue-instantsearch/getting-started/README.md
+++ b/vue-instantsearch/getting-started/README.md
@@ -1,6 +1,6 @@
 # Vue InstantSearch getting started sample
 
-[![Edit getting-started](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/getting-started)
+[![Edit getting-started](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/vue/getting-started)
 
 Also available in [InstantSearch.js](../../instantsearch.js/getting-started/), [React InstantSearch](../../react-instantsearch/getting-started/), [React InstantSearch Hooks](../../react-instantsearch-hooks/getting-started/) and [Angular InstantSearch](../../angular-instantsearch/getting-started/)
 

--- a/vue-instantsearch/getting-started/README.md
+++ b/vue-instantsearch/getting-started/README.md
@@ -1,5 +1,7 @@
 # Vue InstantSearch getting started sample
 
+[![Edit getting-started](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/getting-started)
+
 Also available in [InstantSearch.js](../../instantsearch.js/getting-started/), [React InstantSearch](../../react-instantsearch/getting-started/), [React InstantSearch Hooks](../../react-instantsearch-hooks/getting-started/) and [Angular InstantSearch](../../angular-instantsearch/getting-started/)
 
 ---

--- a/vue-instantsearch/infinite-scroll/README.md
+++ b/vue-instantsearch/infinite-scroll/README.md
@@ -1,5 +1,7 @@
 # vue-instantsearch-v2-starter
 
+[![Edit infinite-scroll](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/infinite-scroll)
+
 ## Project setup
 ```
 yarn install

--- a/vue-instantsearch/loading-indicator/README.md
+++ b/vue-instantsearch/loading-indicator/README.md
@@ -1,5 +1,7 @@
 # vue-instantsearch-v2-starter
 
+[![Edit loading-indicator](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/loading-indicator)
+
 ## Project setup
 ```
 yarn install

--- a/vue-instantsearch/media/README.md
+++ b/vue-instantsearch/media/README.md
@@ -1,6 +1,6 @@
 # Vue Instantsearch media sample
 
-[![Edit media](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/media)
+[![Edit media](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/vue/media)
 
 Also available in [InstantSearch](../../instantsearch.js/media/), [Angular InstantSearch](../../angular-instantsearch/media/) and [React InstantSearch](../../react-instantsearch/media/)
 

--- a/vue-instantsearch/media/README.md
+++ b/vue-instantsearch/media/README.md
@@ -1,5 +1,7 @@
 # Vue Instantsearch media sample
 
+[![Edit media](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/media)
+
 Also available in [InstantSearch](../../instantsearch.js/media/), [Angular InstantSearch](../../angular-instantsearch/media/) and [React InstantSearch](../../react-instantsearch/media/)
 
 ---

--- a/vue-instantsearch/multi-index-autocomplete/README.md
+++ b/vue-instantsearch/multi-index-autocomplete/README.md
@@ -1,5 +1,7 @@
 # vue-instantsearch-v2-starter
 
+[![Edit multi-index-autocomplete](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/multi-index-autocomplete)
+
 ## Project setup
 ```
 yarn install

--- a/vue-instantsearch/multi-index-hits/README.md
+++ b/vue-instantsearch/multi-index-hits/README.md
@@ -1,5 +1,7 @@
 # vue-instantsearch-v2-starter
 
+[![Edit multi-index-hits](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/multi-index-hits)
+
 ## Project setup
 ```
 yarn install

--- a/vue-instantsearch/nuxt/README.md
+++ b/vue-instantsearch/nuxt/README.md
@@ -1,5 +1,7 @@
 # Vue Instantsearch nuxt sample
 
+[![Edit nuxt](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/nuxt)
+
 This sample shows how to integrate Vue InstantSearch with the Nuxt framework.
 
 You can find this demo on [the InstantSearch repository](https://github.com/algolia/instantsearch/tree/master/examples/vue/nuxt), or on [CodeSandbox](https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/vue/nuxt).

--- a/vue-instantsearch/nuxt/README.md
+++ b/vue-instantsearch/nuxt/README.md
@@ -1,7 +1,5 @@
 # Vue Instantsearch nuxt sample
 
-[![Edit nuxt](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/nuxt)
-
 This sample shows how to integrate Vue InstantSearch with the Nuxt framework.
 
 You can find this demo on [the InstantSearch repository](https://github.com/algolia/instantsearch/tree/master/examples/vue/nuxt), or on [CodeSandbox](https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/vue/nuxt).

--- a/vue-instantsearch/places/README.md
+++ b/vue-instantsearch/places/README.md
@@ -1,5 +1,3 @@
 # Places sample
 
-[![Edit places](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/places)
-
 Places is no longer available. [Read our blog post announcement](https://www.algolia.com/blog/product/sunsetting-our-places-feature/) for more information, and alternatives.

--- a/vue-instantsearch/places/README.md
+++ b/vue-instantsearch/places/README.md
@@ -1,3 +1,5 @@
 # Places sample
 
+[![Edit places](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/places)
+
 Places is no longer available. [Read our blog post announcement](https://www.algolia.com/blog/product/sunsetting-our-places-feature/) for more information, and alternatives.

--- a/vue-instantsearch/query-suggestions/README.md
+++ b/vue-instantsearch/query-suggestions/README.md
@@ -1,5 +1,7 @@
 # vue-instantsearch-v2-starter
 
+[![Edit query-suggestions](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/query-suggestions)
+
 ## Project setup
 ```
 yarn install

--- a/vue-instantsearch/refresh/README.md
+++ b/vue-instantsearch/refresh/README.md
@@ -1,5 +1,7 @@
 # vue-instantsearch-v2-starter
 
+[![Edit refresh](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/refresh)
+
 ## Project setup
 ```
 yarn install

--- a/vue-instantsearch/routing-basic/README.md
+++ b/vue-instantsearch/routing-basic/README.md
@@ -1,5 +1,7 @@
 # vue-instantsearch-routing-basic
 
+[![Edit routing-basic](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/routing-basic)
+
 ## Project setup
 ```
 yarn install

--- a/vue-instantsearch/routing-seo-friendly/README.md
+++ b/vue-instantsearch/routing-seo-friendly/README.md
@@ -1,5 +1,7 @@
 # vue-instantsearch-routing-full-url
 
+[![Edit routing-seo-friendly](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/routing-seo-friendly)
+
 ## Project setup
 ```
 yarn install

--- a/vue-instantsearch/routing-state-mapping/README.md
+++ b/vue-instantsearch/routing-state-mapping/README.md
@@ -1,5 +1,7 @@
 # vue-instantsearch-v2-starter
 
+[![Edit routing-state-mapping](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/routing-state-mapping)
+
 ## Project setup
 ```
 yarn install

--- a/vue-instantsearch/routing-vue-router/README.md
+++ b/vue-instantsearch/routing-vue-router/README.md
@@ -1,5 +1,7 @@
 # vue-instantsearch-v2-starter
 
+[![Edit routing-vue-router](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/routing-vue-router)
+
 ## Project setup
 ```
 yarn install

--- a/vue-instantsearch/secured-api-keys/README.md
+++ b/vue-instantsearch/secured-api-keys/README.md
@@ -1,5 +1,7 @@
 # secured-api-keys
 
+[![Edit secured-api-keys](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/secured-api-keys)
+
 ## Project setup
 ```
 yarn install

--- a/vue-instantsearch/server-side-rendering/README.md
+++ b/vue-instantsearch/server-side-rendering/README.md
@@ -1,5 +1,7 @@
 # ssr
 
+[![Edit server-side-rendering](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/server-side-rendering)
+
 ## Project setup
 ```
 yarn install

--- a/vue-instantsearch/vue3-ssr-vite/README.md
+++ b/vue-instantsearch/vue3-ssr-vite/README.md
@@ -1,5 +1,7 @@
 # Vue InstantSearch with Vue 3 + SSR + vite
 
+[![Edit vue3-ssr-vite](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/vue3-ssr-vite)
+
 This repository is based on https://github.com/vitejs/vite/tree/b1598cec7ee185f796d8679f0a97d36b80fe1949/packages/playground/ssr-vue
 
 ## Getting Started

--- a/vue-instantsearch/vue3-ssr-vue-cli/README.md
+++ b/vue-instantsearch/vue3-ssr-vue-cli/README.md
@@ -1,5 +1,7 @@
 # Vue InstantSearch with Vue 3 + SSR + Vue CLI
 
+[![Edit vue3-ssr-vue-cli](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/vue3-ssr-vue-cli)
+
 This repository is based on https://github.com/moduslabs/vue3-example-ssr
 
 ## Getting Started

--- a/vue-instantsearch/vue3-vite/README.md
+++ b/vue-instantsearch/vue3-vite/README.md
@@ -1,5 +1,7 @@
 # Vue InstantSearch with Vue 3 + vite
 
+[![Edit vue3-vite](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/vue3-vite)
+
 ## Getting Started
 
 ```sh

--- a/vue-instantsearch/vue3-vue-cli/README.md
+++ b/vue-instantsearch/vue3-vue-cli/README.md
@@ -1,5 +1,7 @@
 # Vue InstantSearch with Vue 3 + Vue CLI
 
+[![Edit vue3-vue-cli](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/doc-code-samples/tree/master/vue-instantsearch/vue3-vue-cli)
+
 ## Getting Started
 
 ```sh


### PR DESCRIPTION
Quick PR to add links to code sandboxes for all the code samples in this repository.

For Angular InstantSearch code samples, the links redirect to the appropriate branch.