### PR TITLE
Fix: Update Old CDN Links

### DIFF
--- a/instantsearch.js/algolia-insights/index.html
+++ b/instantsearch.js/algolia-insights/index.html
@@ -39,8 +39,8 @@
       </div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/algoliasearch@4/dist/algoliasearch-lite.umd.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@4"></script>
+    <script src="https://cdn.jsdelivr.net/npm/algoliasearch@4.18.0/dist/algoliasearch-lite.umd.js" integrity="sha256-V3GHVlMSAsogT3wL0OY/l4d3fRLa56gNzlnzdIMBIWg=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@4.56.3/dist/instantsearch.production.min.js" integrity="sha256-mWvjWAfZylKMOg+S3HLq+wng1HHRnl2Idr2r8NsUzIU=" crossorigin="anonymous"></script>
     <script src="./src/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Update CDN Links to support the new templating system introduced in version 4.46. Current versions will throw an error.