### PR TITLE
fix(facet-dropdown): dropdown closes even if clicked inside

### DIFF
--- a/instantsearch.js/facet-dropdown/src/Dropdown.js
+++ b/instantsearch.js/facet-dropdown/src/Dropdown.js
@@ -90,7 +90,7 @@ export function createDropdown(
       setTimeout(() => {
         state.windowClickListener = event => {
           // Close if the outside is clicked
-          if (!rootElem.contains(event.target)) {
+          if (!event.composedPath().includes(rootElem)) {
             close();
           }
         };


### PR DESCRIPTION
### [CR-4001](https://algolia.atlassian.net/browse/CR-4001)

In the case of `refinementList` for example, clicking on an item would always close the dropdown even if it is inside because they are always completely rebuilt instead of mutated ([key gets changed when refined](https://github.com/algolia/instantsearch/blob/c207de362a829f6bf44e1fe51e8a4e4a44d7d240/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx#L161C1-L167C6)), thus the `rootElem.contains(event.target)` condition would always return `false`.

By using `composedPath()` instead of relying on a DOM element that might disappear, this fixes the behavior observed in the issue.

[CR-4001]: https://algolia.atlassian.net/browse/CR-4001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ